### PR TITLE
Message Router - eliminate deadlocks and blockig in the message processing pipeline

### DIFF
--- a/Tryouts/Messaging-JS/src/TopicSubscriber.ts
+++ b/Tryouts/Messaging-JS/src/TopicSubscriber.ts
@@ -1,4 +1,4 @@
 import { PartialObserver } from "rxjs";
 import { TopicMessage } from "./TopicMessage";
 
-export type TopicSubscriber = PartialObserver<TopicMessage>;
+export type TopicSubscriber = PartialObserver<TopicMessage> | ((message: TopicMessage) => void);

--- a/Tryouts/Messaging/Client/Client/MessageRouterClient.cs
+++ b/Tryouts/Messaging/Client/Client/MessageRouterClient.cs
@@ -612,14 +612,14 @@ internal sealed class MessageRouterClient : IMessageRouter
                 }
                 catch (Exception e)
                 {
+                    _logger.LogError(
+                        e,
+                        "Exception thrown while processing messages for a subscriber of topic '{Topic}': {ExceptionMessage}",
+                        _topic.Name,
+                        e.Message);
+
                     try
                     {
-                        _logger.LogError(
-                            e,
-                            "Exception thrown while processing messages for a subscriber of topic '{Topic}': {ExceptionMessage}",
-                            _topic.Name,
-                            e.Message);
-
                         await _subscriber.OnErrorAsync(e is ChannelClosedException ? e.InnerException ?? e : e);
                     }
                     catch (Exception e2)
@@ -628,7 +628,7 @@ internal sealed class MessageRouterClient : IMessageRouter
                             e2,
                             $"Exception thrown while invoking {nameof(ISubscriber<T>.OnErrorAsync)} on a subscriber of topic '{{TopicName}}': {{ExceptionMessage}}",
                             _topic.Name,
-                            e.Message);
+                            e2.Message);
                     }
                 }
             }


### PR DESCRIPTION
The .NET client is now processing messages synchronously, each subscriber having its own async message queue.
The JS client never had this issue, but now it's proven by tests.