### PR TITLE
Fix dotnet build for CI Jobs

### DIFF
--- a/.github/workflows/continuous-integration-prototypes.yml
+++ b/.github/workflows/continuous-integration-prototypes.yml
@@ -25,11 +25,11 @@ jobs:
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
     - name: Install dependencies
-      run: Get-ChildItem -Path Prototypes -Recurse -Include *.sln | ForEach-Object {dotnet restore $_} 
+      run: Get-ChildItem -Recurse -Include *.sln | ForEach-Object {dotnet restore $_} 
       working-directory: Tryouts
     - name: Build
-      run: Get-ChildItem -Path Prototypes -Recurse -Include *.sln | ForEach-Object {dotnet build $_ --configuration Release --no-restore} 
+      run: Get-ChildItem -Recurse -Include *.sln | ForEach-Object {dotnet build $_ --configuration Release --no-restore} 
       working-directory: Tryouts
     - name: Test
-      run: Get-ChildItem -Path Prototypes -Recurse -Include *.sln | ForEach-Object {dotnet test $_ --no-restore --verbosity normal}  
+      run: Get-ChildItem -Recurse -Include *.sln | ForEach-Object {dotnet test $_ --no-restore --verbosity normal}  
       working-directory: Tryouts

--- a/.github/workflows/continuous-integration-prototypes.yml
+++ b/.github/workflows/continuous-integration-prototypes.yml
@@ -28,7 +28,7 @@ jobs:
       run: Get-ChildItem -Recurse -Include *.sln | ForEach-Object {dotnet restore $_} 
       working-directory: Tryouts
     - name: Build
-      run: Get-ChildItem -Recurse -Include *.sln | ForEach-Object {dotnet build $_ --configuration Release --no-restore} 
+      run: Get-ChildItem -Recurse -Include *.sln | ForEach-Object {dotnet build $_ --configuration Release --no-restore; if ($LASTEXITCODE -ne 0 ) {throw "Build for $_ FAILED"; }} 
       working-directory: Tryouts
     - name: Test
       run: Get-ChildItem -Recurse -Include *.sln | ForEach-Object {dotnet test $_ --no-restore --verbosity normal}  

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,7 +28,7 @@ jobs:
       run: Get-ChildItem -Recurse -Include *.sln | ForEach-Object {dotnet restore $_} 
       working-directory: src
     - name: Build
-      run: Get-ChildItem -Recurse -Include *.sln | ForEach-Object {dotnet build $_ --configuration Release --no-restore}
+      run: Get-ChildItem -Recurse -Include *.sln | ForEach-Object {dotnet build $_ --configuration Release --no-restore; if ($LASTEXITCODE -ne 0 ) {throw "Build for $_ FAILED"; }}
       working-directory: src
     - name: Test
       run: Get-ChildItem -Recurse -Include *.sln | ForEach-Object {dotnet test $_ --no-restore --verbosity normal}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,11 +25,11 @@ jobs:
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
     - name: Install dependencies
-      run: dotnet restore
+      run: Get-ChildItem -Recurse -Include *.sln | ForEach-Object {dotnet restore $_} 
       working-directory: src
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: Get-ChildItem -Recurse -Include *.sln | ForEach-Object {dotnet build $_ --configuration Release --no-restore}
       working-directory: src
     - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      run: Get-ChildItem -Recurse -Include *.sln | ForEach-Object {dotnet test $_ --no-restore --verbosity normal}
       working-directory: src


### PR DESCRIPTION
These changes are allowing the CI build to pick up all the solutions both in the src and the Tryouts folders.