### PR TITLE
Message Router - better error handling, handle disconnected clients

### DIFF
--- a/Tryouts/Messaging/Client/Client/Abstractions/IConnection.cs
+++ b/Tryouts/Messaging/Client/Client/Abstractions/IConnection.cs
@@ -32,6 +32,8 @@ internal interface IConnection : IAsyncDisposable
     /// <param name="message"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
+    /// <exception cref="MessageRouterException">With name <see cref="MessageRouterErrors.ConnectionClosed"/> if the connection was closed by either party while sending the request</exception>
+    /// <exception cref="MessageRouterException">With name <see cref="MessageRouterErrors.ConnectionAborted"/> if the connection was closed due to an unexpected error</exception>
     ValueTask SendAsync(Message message, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -39,5 +41,7 @@ internal interface IConnection : IAsyncDisposable
     /// </summary>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
+    /// <exception cref="MessageRouterException">With name <see cref="MessageRouterErrors.ConnectionClosed"/> if the connection was closed by either party while sending the request</exception>
+    /// <exception cref="MessageRouterException">With name <see cref="MessageRouterErrors.ConnectionAborted"/> if the connection was closed due to an unexpected error</exception>
     ValueTask<Message> ReceiveAsync(CancellationToken cancellationToken = default);
 }

--- a/Tryouts/Messaging/Client/MorganStanley.ComposeUI.Messaging.Client.csproj
+++ b/Tryouts/Messaging/Client/MorganStanley.ComposeUI.Messaging.Client.csproj
@@ -12,6 +12,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.4.0" />
 	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
 	  <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />

--- a/Tryouts/Messaging/Core/Exceptions/ThrowHelper.cs
+++ b/Tryouts/Messaging/Core/Exceptions/ThrowHelper.cs
@@ -10,8 +10,6 @@
 // or implied. See the License for the specific language governing permissions
 // and limitations under the License.
 
-using MorganStanley.ComposeUI.Messaging.Protocol.Messages;
-
 #pragma warning disable CS1591
 namespace MorganStanley.ComposeUI.Messaging.Exceptions;
 
@@ -42,6 +40,12 @@ public static class ThrowHelper
     public static MessageRouterException ConnectionFailed() =>
         new(MessageRouterErrors.ConnectionFailed, "Connection failed");
 
+    public static MessageRouterException ConnectionFailed(Exception innerException) =>
+        new(MessageRouterErrors.ConnectionFailed, "Connection failed.\n\r{innerException.Message}'", innerException);
+
     public static MessageRouterException ConnectionAborted() =>
         new(MessageRouterErrors.ConnectionAborted, "The connection dropped unexpectedly");
+
+    public static MessageRouterException ConnectionAborted(Exception innerException) =>
+        new(MessageRouterErrors.ConnectionAborted, $"The connection dropped unexpectedly.\n\r{innerException.Message}", innerException);
 }

--- a/Tryouts/Messaging/Core/MessageRouterException.cs
+++ b/Tryouts/Messaging/Core/MessageRouterException.cs
@@ -31,6 +31,17 @@ public class MessageRouterException : Exception
     }
 
     /// <summary>
+    /// Creates a new instance of <see cref="MessageRouterException"/> with the provided error name, message and inner exception.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="message"></param>
+    /// <param name="innerException"></param>
+    public MessageRouterException(string name, string message, Exception innerException) : base(message, innerException)
+    {
+        Name = name;
+    }
+
+    /// <summary>
     /// Creates a new instance of <see cref="MessageRouterException"/> from the provided <see cref="Error"/> object.
     /// </summary>
     /// <param name="error"></param>

--- a/Tryouts/Messaging/IntegrationTests/WebSocketEndToEndTests.cs
+++ b/Tryouts/Messaging/IntegrationTests/WebSocketEndToEndTests.cs
@@ -10,12 +10,10 @@
 // or implied. See the License for the specific language governing permissions
 // and limitations under the License.
 
-using System.Reactive;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using MorganStanley.ComposeUI.Messaging.Client.WebSocket;
-using MorganStanley.ComposeUI.Messaging.Exceptions;
 using MorganStanley.ComposeUI.Messaging.Server.WebSocket;
 using Nito.AsyncEx;
 

--- a/Tryouts/Messaging/Server.Tests/MessageRouterServer.WebSocket.Tests.cs
+++ b/Tryouts/Messaging/Server.Tests/MessageRouterServer.WebSocket.Tests.cs
@@ -14,7 +14,6 @@ using System.Net.WebSockets;
 using FluentAssertions.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using MorganStanley.ComposeUI.Messaging.Exceptions;
 using MorganStanley.ComposeUI.Messaging.Server.WebSocket;
 using MorganStanley.ComposeUI.Messaging.TestUtils;
 

--- a/Tryouts/Messaging/Server/Server/Abstractions/IClientConnection.cs
+++ b/Tryouts/Messaging/Server/Server/Abstractions/IClientConnection.cs
@@ -25,6 +25,8 @@ public interface IClientConnection : IAsyncDisposable
     /// <param name="message"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
+    /// <exception cref="MessageRouterException">With name <see cref="MessageRouterErrors.ConnectionClosed"/> if the connection was closed by either party while sending the request</exception>
+    /// <exception cref="MessageRouterException">With name <see cref="MessageRouterErrors.ConnectionAborted"/> if the connection was closed due to an unexpected error</exception>
     ValueTask SendAsync(Message message, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -32,5 +34,7 @@ public interface IClientConnection : IAsyncDisposable
     /// </summary>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
+    /// <exception cref="MessageRouterException">With name <see cref="MessageRouterErrors.ConnectionClosed"/> if the connection was closed by either party while sending the request</exception>
+    /// <exception cref="MessageRouterException">With name <see cref="MessageRouterErrors.ConnectionAborted"/> if the connection was closed due to an unexpected error</exception>
     ValueTask<Message> ReceiveAsync(CancellationToken cancellationToken = default);
 }

--- a/Tryouts/Plugins/ApplicationPlugins/ComposeUI.Example.DataService/Program.cs
+++ b/Tryouts/Plugins/ApplicationPlugins/ComposeUI.Example.DataService/Program.cs
@@ -43,6 +43,20 @@ class Program
         var monthlySalesDataService = serviceProvider.GetRequiredService<MonthlySalesDataService>();
         await monthlySalesDataService.Start();
 
-        Console.ReadLine();
+        var stopTaskSource = new TaskCompletionSource();
+
+        Console.CancelKeyPress += (sender, args) =>
+        {
+            stopTaskSource.SetResult();
+            args.Cancel = true;
+        };
+
+        await stopTaskSource.Task;
+
+        Console.WriteLine("Exiting");
+
+        await serviceProvider.DisposeAsync();
+
+        Console.WriteLine("Done");
     }
 }

--- a/Tryouts/Prototypes/ModulesPrototype/manifest.json
+++ b/Tryouts/Prototypes/ModulesPrototype/manifest.json
@@ -17,7 +17,7 @@
     "StartupType": "selfhostedwebapp",
     "UIType": "web",
     "Name": "chart",
-    "Path": "..\\..\\..\\..\\..\\Plugins\\ApplicationPlugins\\chart\\src",
+    "Path": "..\\..\\..\\..\\..\\Plugins\\ApplicationPlugins\\chart",
     "Port": 8080,
     "Url": "http://localhost:8080"
   }


### PR DESCRIPTION
More consistent handling of errors when the connection drops from either side.
To validate, run the modules prototype and start exiting/killing modules.
Errors should be logged on the server only when the client is killed without properly closing the connection. The server should not crash in either case.