### PR TITLE
Github Action: Deploy ready-to-release packages to NPM

### DIFF
--- a/.github/workflows/deploy-to-npm.yml
+++ b/.github/workflows/deploy-to-npm.yml
@@ -4,11 +4,11 @@ on:
   release:
     types: [published]
 jobs:
-  build:
-    uses: ./.github/workflows/continuous-integration-prototypes.yml
+  release:
+    uses: ./.github/workflows/release.yml
   deploy-npm:
     name: Deploy packages to NPM
-    needs: build
+    needs: release
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy-to-npm.yml
+++ b/.github/workflows/deploy-to-npm.yml
@@ -1,0 +1,24 @@
+name: Publish Package to npmjs
+
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    uses: ./.github/workflows/continuous-integration-prototypes.yml
+  deploy-npm:
+    name: Deploy packages to NPM
+    needs: build
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: [ '18.x' ]
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npx lerna run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Tryouts/Plugins/ApplicationPlugins/defaultApp/package.json
+++ b/Tryouts/Plugins/ApplicationPlugins/defaultApp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morgan-stanley/composeui-example-default",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.1",
   "private": true,
   "description": "ComposeUI Default App",
   "main": "app.js",

--- a/Tryouts/Plugins/ApplicationPlugins/defaultApp/package.json
+++ b/Tryouts/Plugins/ApplicationPlugins/defaultApp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@morgan-stanley/composeui-example-default",
   "version": "0.1.0",
+  "private": true,
   "description": "ComposeUI Default App",
   "main": "app.js",
   "type": "module",

--- a/Tryouts/Plugins/ApplicationPlugins/process explorer/package.json
+++ b/Tryouts/Plugins/ApplicationPlugins/process explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morgan-stanley/composeui-process-explorer-frontend",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.1",
   "private": true,
   
   "scripts": {

--- a/Tryouts/Plugins/ApplicationPlugins/process explorer/package.json
+++ b/Tryouts/Plugins/ApplicationPlugins/process explorer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@morgan-stanley/composeui-process-explorer-frontend",
   "version": "0.1.0",
+  "private": true,
   
   "scripts": {
     "ng": "ng",

--- a/examples/js-chart/package.json
+++ b/examples/js-chart/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@morgan-stanley/composeui-example-chart",
-  "version": "0.1.0",
+  "name": "@morgan-stanley/composeui-example-chart",  
+  "version": "0.1.0-alpha.1",
   "private": true,
   "description": "Example Web Application",
   "main": "chat.js",

--- a/examples/js-chart/package.json
+++ b/examples/js-chart/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@morgan-stanley/composeui-example-chart",
   "version": "0.1.0",
+  "private": true,
   "description": "Example Web Application",
   "main": "chat.js",
   "type": "module",

--- a/examples/js-datagrid/package.json
+++ b/examples/js-datagrid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morgan-stanley/composeui-example-grid",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.1",
   "private": true,
   "scripts": {
     "ng": "ng",

--- a/examples/js-datagrid/package.json
+++ b/examples/js-datagrid/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@morgan-stanley/composeui-example-grid",
   "version": "0.1.0",
+  "private": true,
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -8,7 +9,6 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test --watch=false"
   },
-  "private": true,
   "dependencies": {
     "@angular/animations": "^15.1.0",
     "@angular/cdk": "~15.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
     },
     "examples/js-chart": {
       "name": "@morgan-stanley/composeui-example-chart",
-      "version": "0.1.0",
+      "version": "0.1.0-alpha.1",
       "dependencies": {
         "@morgan-stanley/composeui-messaging-client": "*",
         "bootstrap": "5.2.3",
@@ -95,7 +95,7 @@
     },
     "examples/js-datagrid": {
       "name": "@morgan-stanley/composeui-example-grid",
-      "version": "0.1.0",
+      "version": "0.1.0-alpha.1",
       "dependencies": {
         "@angular/animations": "^15.1.0",
         "@angular/cdk": "~15.1.4",
@@ -20889,7 +20889,7 @@
     },
     "src/messaging/js/composeui-messaging-client": {
       "name": "@morgan-stanley/composeui-messaging-client",
-      "version": "0.1.0",
+      "version": "0.1.0-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^18.11.18",
@@ -20974,7 +20974,7 @@
     },
     "src/shell/js/composeui-node-launcher": {
       "name": "@morgan-stanley/composeui-node-launcher",
-      "version": "0.1.0",
+      "version": "0.1.0-alpha.1",
       "hasInstallScript": true,
       "bin": {
         "composeui": "output/cli/cli.js"
@@ -20994,7 +20994,7 @@
     },
     "src/shell/js/composeui-node-launcher-example": {
       "name": "@morgan-stanley/composeui-node-launcher-example",
-      "version": "0.1.0",
+      "version": "0.1.0-alpha.1",
       "dependencies": {
         "@morgan-stanley/composeui-node-launcher": "*"
       }
@@ -21168,14 +21168,14 @@
     },
     "Tryouts/Plugins/ApplicationPlugins/defaultApp": {
       "name": "@morgan-stanley/composeui-example-default",
-      "version": "0.1.0",
+      "version": "0.1.0-alpha.1",
       "devDependencies": {
         "http-server": "14.1.1"
       }
     },
     "Tryouts/Plugins/ApplicationPlugins/process explorer": {
       "name": "@morgan-stanley/composeui-process-explorer-frontend",
-      "version": "0.1.0",
+      "version": "0.1.0-alpha.1",
       "dependencies": {
         "@angular/animations": "^15.1.0",
         "@angular/common": "^15.1.0",

--- a/src/messaging/js/composeui-messaging-client/package.json
+++ b/src/messaging/js/composeui-messaging-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@morgan-stanley/composeui-messaging-client",
-    "version": "0.1.0",
+    "version": "0.1.0-alpha.1",
     "private": true,
     "description": "JavaScript client for Compose UI's Message Router",
     "type": "module",

--- a/src/messaging/js/composeui-messaging-client/package.json
+++ b/src/messaging/js/composeui-messaging-client/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@morgan-stanley/composeui-messaging-client",
     "version": "0.1.0",
+    "private": true,
     "description": "JavaScript client for Compose UI's Message Router",
     "type": "module",
     "files": [

--- a/src/shell/js/composeui-node-launcher-example/package.json
+++ b/src/shell/js/composeui-node-launcher-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morgan-stanley/composeui-node-launcher-example",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.1",
   "private": true,
   "description": "Example usage of @morgan-stanley/composeui-node-launcher-example",
   "main": "example.js",

--- a/src/shell/js/composeui-node-launcher-example/package.json
+++ b/src/shell/js/composeui-node-launcher-example/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@morgan-stanley/composeui-node-launcher-example",
   "version": "0.1.0",
+  "private": true,
   "description": "Example usage of @morgan-stanley/composeui-node-launcher-example",
   "main": "example.js",
   "module": "example.js",

--- a/src/shell/js/composeui-node-launcher/package.json
+++ b/src/shell/js/composeui-node-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morgan-stanley/composeui-node-launcher",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.1",
   "private": false,
   "description": "Package to launch Compose from Node.js",
   "main": "output/index.js",

--- a/src/shell/js/composeui-node-launcher/package.json
+++ b/src/shell/js/composeui-node-launcher/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@morgan-stanley/composeui-node-launcher",
   "version": "0.1.0",
+  "private": false,
   "description": "Package to launch Compose from Node.js",
   "main": "output/index.js",
   "module": "output/index.js",


### PR DESCRIPTION
* Trigger: published release (manually on web ui)
* Pre-requisite: Successful Binary Publish to Tagged Release Assets
* Setting the node packages that we don't want to release for now to *"private": true*
* Adding script to deploy @morgan-stanley/composeui-node-launcher to NPM

Note: Setting the version numbers for packages to 0.1.0-alpha.1 will be a separate PR.
Expectation: only @morgan-stanley/composeui-node-launcher is deployed to NPM