### PR TITLE
Github Actions: Fix Release and deploy-to-npm

### DIFF
--- a/.github/workflows/deploy-to-npm.yml
+++ b/.github/workflows/deploy-to-npm.yml
@@ -1,21 +1,21 @@
 name: Publish Package to npmjs
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+  
 jobs:
-  release:
-    uses: ./.github/workflows/release.yml
   deploy-npm:
     name: Deploy packages to NPM
-    needs: release
     runs-on: windows-latest
+    strategy:
+      matrix:
+        node-version: [ '18.x' ]
     steps:
       - uses: actions/checkout@v3
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
-          node-version: [ '18.x' ]
+          node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npx lerna run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,8 @@ on:
   workflow_call:
 
 permissions:
-  contents: read
+  contents: write
+  actions: read
 
 name: Upload Release Asset
 
@@ -45,3 +46,6 @@ jobs:
           asset_name: composeui-${{ github.ref_name }}-win32.zip
           asset_content_type: application/zip
           
+  deploy:
+    uses: ./.github/workflows/deploy-to-npm.yml
+    needs: upload


### PR DESCRIPTION
* The release job calls deploy-to-npm instead of trigger
* Sufficient permissions are granted to the Release workflow so it can upload the asset file
* Trigger for Release: Manually created release on the web UI 