### PR TITLE
`Topic` extensions for Message Router client

### DIFF
--- a/prototypes/multi-module-prototype/examples/multi-module-example/ComposeUI.Example.DataService/MonthlySalesDataService.cs
+++ b/prototypes/multi-module-prototype/examples/multi-module-example/ComposeUI.Example.DataService/MonthlySalesDataService.cs
@@ -19,11 +19,11 @@ using MorganStanley.ComposeUI.Messaging;
 
 namespace ComposeUI.Example.DataService
 {
-    internal class MonthlySalesDataService : IDisposable
+    internal class MonthlySalesDataService : IAsyncDisposable
     {
         private readonly IMessageRouter _messageRouter;
         private readonly ILogger<MonthlySalesDataService>? _logger;
-        private readonly List<IDisposable> _subscriptions = new();
+        private readonly List<IAsyncDisposable> _subscriptions = new();
 
         public MonthlySalesDataService(IMessageRouter messageRouter, ILogger<MonthlySalesDataService>? logger = null)
         {
@@ -84,12 +84,11 @@ namespace ComposeUI.Example.DataService
             return default;
         }
 
-        public void Dispose()
+        public ValueTask DisposeAsync()
         {
-            foreach (var subscription in _subscriptions)
-            {
-                subscription.Dispose();
-            }
+            return new ValueTask(
+                Task.WhenAll(
+                    _subscriptions.Select(x => x.DisposeAsync().AsTask())));
         }
 
         private class SymbolSelectedModel

--- a/src/messaging/dotnet/src/Client/MessageRouterClientExtensions.cs
+++ b/src/messaging/dotnet/src/Client/MessageRouterClientExtensions.cs
@@ -1,0 +1,45 @@
+﻿// Morgan Stanley makes this available to you under the Apache License,
+// Version 2.0 (the "License"). You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0.
+// 
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership. Unless required by applicable law or agreed
+// to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions
+// and limitations under the License.
+
+using MorganStanley.ComposeUI.Messaging.Client;
+
+namespace MorganStanley.ComposeUI.Messaging;
+
+/// <summary>
+///     Provides extensions methods for <see cref="IMessageRouter" />
+/// </summary>
+public static class MessageRouterClientExtensions
+{
+    public static IAsyncObservable<TopicMessage> Topic(this IMessageRouter messageRouter, string topic)
+    {
+        return messageRouter is MessageRouterClient messageRouterClient
+            ? messageRouterClient.GetTopicObservable(topic)
+            : new TopicObservable(messageRouter, topic);
+    }
+
+    private sealed class TopicObservable : IAsyncObservable<TopicMessage>
+    {
+        public TopicObservable(IMessageRouter messageRouter, string topic)
+        {
+            _messageRouter = messageRouter;
+            _topic = topic;
+        }
+
+        public ValueTask<IAsyncDisposable> SubscribeAsync(IAsyncObserver<TopicMessage> observer)
+        {
+            return _messageRouter.SubscribeAsync(_topic, observer, CancellationToken.None);
+        }
+
+        private readonly IMessageRouter _messageRouter;
+        private readonly string _topic;
+    }
+}

--- a/src/messaging/dotnet/src/Core/IMessageRouter.cs
+++ b/src/messaging/dotnet/src/Core/IMessageRouter.cs
@@ -43,7 +43,7 @@ public interface IMessageRouter : IAsyncDisposable
     /// <param name="subscriber"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    ValueTask<IDisposable> SubscribeAsync(
+    ValueTask<IAsyncDisposable> SubscribeAsync(
         string topic,
         IAsyncObserver<TopicMessage> subscriber,
         CancellationToken cancellationToken = default);

--- a/src/messaging/dotnet/src/Core/Internal/Disposable.cs
+++ b/src/messaging/dotnet/src/Core/Internal/Disposable.cs
@@ -1,0 +1,51 @@
+﻿// Morgan Stanley makes this available to you under the Apache License,
+// Version 2.0 (the "License"). You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0.
+// 
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership. Unless required by applicable law or agreed
+// to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions
+// and limitations under the License.
+
+namespace MorganStanley.ComposeUI.Messaging.Internal;
+
+internal static class Disposable
+{
+    public static IDisposable FromAsyncDisposable(IAsyncDisposable asyncDisposable) =>
+        new AsyncDisposableWrapper(asyncDisposable);
+
+    public static ValueTask<IDisposable> FromAsyncDisposable(ValueTask<IAsyncDisposable> awaitable)
+    {
+        return awaitable.IsCompletedSuccessfully 
+            ? new ValueTask<IDisposable>(FromAsyncDisposable(awaitable.Result)) 
+            : FromAsyncDisposableImpl(awaitable);
+
+        static async ValueTask<IDisposable> FromAsyncDisposableImpl(ValueTask<IAsyncDisposable> awaitable)
+        {
+            return FromAsyncDisposable(await awaitable);
+        }
+    }
+
+    internal class AsyncDisposableWrapper : IDisposable
+    {
+        public AsyncDisposableWrapper(IAsyncDisposable asyncDisposable)
+        {
+            _asyncDisposable = asyncDisposable;
+        }
+
+        public void Dispose()
+        {
+            var task = _asyncDisposable.DisposeAsync();
+
+            if (task.IsCompletedSuccessfully)
+                return;
+
+            task.GetAwaiter().GetResult();
+        }
+
+        private readonly IAsyncDisposable _asyncDisposable;
+    }
+}

--- a/src/messaging/dotnet/src/Core/MessageRouterExtensions.cs
+++ b/src/messaging/dotnet/src/Core/MessageRouterExtensions.cs
@@ -14,6 +14,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
+using MorganStanley.ComposeUI.Messaging.Internal;
 
 namespace MorganStanley.ComposeUI.Messaging;
 
@@ -110,7 +111,8 @@ public static class MessageRouterExtensions
                 return default;
             });
 
-        return messageRouter.SubscribeAsync(topic, innerSubscriber, cancellationToken);
+        return Disposable.FromAsyncDisposable(
+            messageRouter.SubscribeAsync(topic, innerSubscriber, cancellationToken));
     }
 
     /// <summary>
@@ -149,7 +151,8 @@ public static class MessageRouterExtensions
                 return default;
             });
 
-        return messageRouter.SubscribeAsync(topic, innerSubscriber, cancellationToken);
+        return Disposable.FromAsyncDisposable(
+            messageRouter.SubscribeAsync(topic, innerSubscriber, cancellationToken));
     }
 
     /// <summary>
@@ -161,7 +164,7 @@ public static class MessageRouterExtensions
     /// <param name="subscriber"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    public static ValueTask<IDisposable> SubscribeAsync(
+    public static ValueTask<IAsyncDisposable> SubscribeAsync(
         this IMessageRouter messageRouter,
         string topic,
         IAsyncObserver<string?> subscriber,
@@ -189,7 +192,7 @@ public static class MessageRouterExtensions
     {
         var channel = Channel.CreateUnbounded<TopicMessage>();
 
-        using var subscription = await messageRouter.SubscribeAsync(
+        await using var subscription = await messageRouter.SubscribeAsync(
             topic,
             AsyncObserver.Create<TopicMessage>(
                 onNextAsync: message => channel.Writer.WriteAsync(message, cancellationToken),


### PR DESCRIPTION
Added the `Topic` extension method for obtaining an `IAsyncObservable` for a given topic.