### PR TITLE
Fix lerna build for fdc3 js project

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "examples/js-*",
     "src/messaging/js/*",
     "src/shell/js/*",
+    "src/fdc3/js/*",
     "prototypes/process-explorer/js"
   ],
   "devDependencies": {

--- a/src/shell/js/composeui-fdc3/package.json
+++ b/src/shell/js/composeui-fdc3/package.json
@@ -14,7 +14,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@finos/fdc3": "^2.0.0",
-    "@morgan-stanley/composeui-messaging-client": "^0.1.0-alpha.1",
+    "@morgan-stanley/composeui-messaging-client": "*",
     "@types/node": "^18.11.18",
     "rxjs": "^7.8.1"
   },


### PR DESCRIPTION
The fdc3 project was missing from the lerna project.
The composeui-messaging-client reference pointed to a specific version instead of the monorepo project.