### PR TITLE
Chore(dependabot): Add nuget projects

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,50 @@
 version: 2
 updates:
 
-  - package-ecosystem: "nuget" # See documentation for possible values
+  - package-ecosystem: "nuget"
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
 
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+# Dependabot doesn't support glob syntax. Every solution needs an entry
+
+  - package-ecosystem: "nuget"
+    directory: "/src/fdc3/dotnet/DesktopAgent/src/DesktopAgent" 
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "nuget"
+    directory: "/src/messaging/dotnet/src/Client" 
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "nuget"
+    directory: "/src/messaging/dotnet/src/Core" 
+    schedule:
+      interval: "monthly"  
+    
+  - package-ecosystem: "nuget"
+    directory: "/src/messaging/dotnet/src/Host" 
+    schedule:
+      interval: "monthly"  
+
+  - package-ecosystem: "nuget"
+    directory: "/src/messaging/dotnet/src/Server" 
+    schedule:
+      interval: "monthly"  
+  
+  - package-ecosystem: "nuget"
+    directory: "/src/shell/dotnet/Shell" 
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "nuget"
+    directory: "/prototypes/multi-module-prototype/examples/multi-module-example/ModulesPrototype" 
+    schedule:
+      interval: "monthly"
+
+
+  - package-ecosystem: "npm" 
+    directory: "/" 
     schedule:
       interval: "monthly"


### PR DESCRIPTION
Since dependabot doesn't support glob syntax it can't pick up the nuget dependencies in a multi-project repository easily.
This pull request adds the main projects under the src folder, and one prototype as a test.
Folders are specified for the project files.
I intend to add other projects later.
Tested on my fork