### PR TITLE
chore(process-explorer-frontend): Add back mock processes

### DIFF
--- a/prototypes/process-explorer/js/src/app/main-view/processes/processes.component.html
+++ b/prototypes/process-explorer/js/src/app/main-view/processes/processes.component.html
@@ -22,7 +22,7 @@
       <igx-grid-pinning-actions></igx-grid-pinning-actions>
 
       <!-- custom controls  -->
-      <button title="Stop" igxButton="icon" igxRipple (click)='KillProcessById(actionstrip.context._rowData.PID)'> 
+      <button title="Stop" igxButton="icon" igxRipple> 
         <igx-icon>stop</igx-icon>
       </button>
 

--- a/prototypes/process-explorer/js/src/app/main-view/processes/processes.component.ts
+++ b/prototypes/process-explorer/js/src/app/main-view/processes/processes.component.ts
@@ -19,18 +19,7 @@ export class ProcessesComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.mockProcessesData = this.mockProcessesService.getProcessServiceObjectsProcesses();
-    //depending on implementation, data subscriptions might need to be unsubbed later
-      const throttlingProcesses = this.mockProcessesService.getProcessServiceObject()
-                                      .subjectAddProcesses.pipe(throttleTime(1000));
-      const subscribingToProcesses = throttlingProcesses.subscribe((data) => {
-        this.mockProcessesData = data;
-        this.TreeGrid.markForCheck();
-      });
-  }
-
-  KillProcessById(pid: number){
-    this.mockProcessesService.KillProcessByID(pid);
+    this.mockProcessesService.getData('Processes').subscribe(data => this.mockProcessesData = data);
   }
 }
 

--- a/prototypes/process-explorer/js/src/app/services/mock-processes.service.ts
+++ b/prototypes/process-explorer/js/src/app/services/mock-processes.service.ts
@@ -1,52 +1,13 @@
 /* Morgan Stanley makes this available to you under the Apache License, Version 2.0 (the "License"). You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0. See the NOTICE file distributed with this work for additional information regarding copyright ownership. Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. */
 import { Injectable } from '@angular/core';
-import { SuperRPC } from 'super-rpc';
-import { IProcessInfoAggregator } from '../DTOs/IProcessInfoAggregator';
-import { ProcessInfo } from '../DTOs/ProcessInfo';
-import { ServiceProcessObject } from '../main-view/processes/ServiceProcessObject';
+import { Observable, of } from 'rxjs';
+import { MockProcesses } from './mock-processes';
 
 @Injectable({
   providedIn: 'root'
 })
 export class MockProcessesService {
-
-  private ws: WebSocket = new WebSocket('ws://localhost:5056/processes');
-  private rpc : SuperRPC;
-  private process : ServiceProcessObject;
-  private connected: any;
-  private processController: IProcessInfoAggregator;
-
-  constructor(){
-    this.process = new ServiceProcessObject();
-    this.connected = new Promise( (resolve, reject) => 
-    {
-      try{
-        this.ws.addEventListener('open', async() => {
-          this.rpc = new SuperRPC( () => (Math.random()*1e17).toString(36));
-          this.rpc.connect({
-            sendAsync: (message) => this.ws.send(JSON.stringify(message)),
-            receive: (callback) => { this.ws.addEventListener('message', (msg) => callback(JSON.parse(msg.data)))}
-          });
-        this.rpc.registerHostObject('ServiceProcessObject', this.process, {functions:['AddProcesses', 'AddProcess', 'UpdateProcess', 'TerminateProcess', 
-            'AddRuntimeInfo', 'AddConnections', 'AddConnection', 'UpdateConnection', 'UpdateEnvironmentVariables','UpdateRegistrations', 'UpdateModules', 'AddRuntimeInfos']});
-        await this.rpc.requestRemoteDescriptors();
-        this.processController = this.rpc.getProxyObject('processController');
-        resolve(undefined);
-      })}catch(ex){
-        reject(ex);}
-    });
-  }
-  
-  public getProcessServiceObject() : ServiceProcessObject{
-    return this.process;
-  }
-
-  public getProcessServiceObjectsProcesses() : ProcessInfo[]{
-    return this.process.getProcesses();
-  }
-
-  public KillProcessByID(pid: number) : void{
-    this.processController.RemoveProcessById(pid);
+  public getData(tableName: string): Observable<any[]> {
+    return of(MockProcesses[tableName]);
   }
 }
-

--- a/prototypes/process-explorer/js/src/app/services/mock-processes.ts
+++ b/prototypes/process-explorer/js/src/app/services/mock-processes.ts
@@ -1,0 +1,1193 @@
+/* Morgan Stanley makes this available to you under the Apache License, Version 2.0 (the "License"). You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0. See the NOTICE file distributed with this work for additional information regarding copyright ownership. Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. */
+// tslint:disable
+export const MockProcesses: { [key: string]: any[] } = {
+    'Processes': [
+      {
+        "ProcessName": "process",
+        "PID": 799771,
+        "ProcessStatus": "Running",
+        "StartTime": "2022.02.21. 17:33:06",
+        "ProcessorUsage": "50%",
+        "PhysicalMemoryUsageBit": 61440000,
+        "PriorityLevel": "low",
+        "VirtualMemorySize": 54136,
+        "Children": [
+          {
+            "ProcessName": "process",
+            "PID": 656475,
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "Children": []
+          },
+          {
+            "ProcessName": "process",
+            "PID": 656476,
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "Children": []
+          },
+          {
+            "ProcessName": "process",
+            "PID": 656477,
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "20%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "Children": []
+          }
+        ]
+      },{
+        "ProcessName": "process",
+        "PID": 799772,
+        "ProcessStatus": "Running",
+        "StartTime": "2022.02.21. 17:33:06",
+        "ProcessorUsage": "80%",
+        "PhysicalMemoryUsageBit": 61440000,
+        "PriorityLevel": "low",
+        "VirtualMemorySize": 54136,
+        "Children": [
+          {
+            "ProcessName": "process",
+            "PID": 656471,
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "50%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "Children": []
+          },
+          {
+            "ProcessName": "process",
+            "PID": 656875,
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "Children": []
+          },
+          {
+            "ProcessName": "process",
+            "PID": 659475,
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "Children": []
+          }
+        ]
+      },{
+        "ProcessName": "process",
+        "PID": 799773,
+        "ProcessStatus": "Running",
+        "StartTime": "2022.02.21. 17:33:06",
+        "ProcessorUsage": "10%",
+        "PhysicalMemoryUsageBit": 61440000,
+        "PriorityLevel": "low",
+        "VirtualMemorySize": 54136,
+        "Children": [
+          {
+            "ProcessName": "process",
+            "PID": 656875,
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "Children": []
+          },
+          {
+            "ProcessName": "process",
+            "PID": 636475,
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "20%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "Children": []
+          },
+          {
+            "ProcessName": "process",
+            "PID": 646475,
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "35%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "Children": []
+          }
+        ]
+      },{
+        "ProcessName": "process",
+        "PID": 799774,
+        "ProcessStatus": "Running",
+        "StartTime": "2022.02.21. 17:33:06",
+        "ProcessorUsage": "80%",
+        "PhysicalMemoryUsageBit": 61440000,
+        "PriorityLevel": "high",
+        "VirtualMemorySize": 54136,
+        "Children": [
+          {
+            "ProcessName": "process",
+            "PID": 656275,
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "35%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "Children": []
+          },
+          {
+            "ProcessName": "process",
+            "PID": 656465,
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "Children": []
+          },
+          {
+            "ProcessName": "process",
+            "PID": 656470,
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "Children": []
+          }
+        ]
+      },
+      {
+        "ProcessName": "process",
+        "ProcessStatus": "Running",
+        "StartTime": "2022.02.21. 17:33:06",
+        "ProcessorUsage": "50%",
+        "PhysicalMemoryUsageBit": 61440000,
+        "PriorityLevel": "high",
+        "VirtualMemorySize": 54136,
+        "PID": 296157,
+        "Children": [
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 358399
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 127710
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 902253
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 109835
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "35%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 574816
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "35%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 935472
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 927301
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 877235
+          },
+        ]
+      },
+      {
+        "ProcessName": "process",
+        "ProcessStatus": "Failed",
+        "StartTime": "2022.02.21. 17:33:06",
+        "ProcessorUsage": "80%",
+        "PhysicalMemoryUsageBit": 61440000,
+        "PriorityLevel": "low",
+        "VirtualMemorySize": 54136,
+        "PID": 193308,
+        "Children": [
+            {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "35%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 943034
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 442246
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "50%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 303510
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 185375
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 527274
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "35%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 910386
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 277153
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 370179
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "50%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 904799
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "50%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 368038
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "35%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 808082
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 333815
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 740085
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 992341
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 947782
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "35%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 548167
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 604815
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "50%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 661522
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "66%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 290849
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 410405
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 943765
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "66%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 198425
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 825940
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 845147
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "50%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 718785
+          },
+        ]
+      },
+      {
+        "ProcessName": "process",
+        "ProcessStatus": "Stopped",
+        "StartTime": "2022.02.21. 17:33:06",
+        "ProcessorUsage": "80%",
+        "PhysicalMemoryUsageBit": 61440000,
+        "PriorityLevel": "medium",
+        "VirtualMemorySize": 54136,
+        "PID": 378783,
+        "Children": [
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 146500
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 868992
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "66%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 238213
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 538328
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "66%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 306101
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "66%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 945050
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 611286
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 505516
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 901785
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 901641
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 615974
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 410628
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "66%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 444108
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "66%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 568185
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 107206
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 704669
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 278425
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 319446
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 573174
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 153095
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 368121
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 330755
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "66%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 996350
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 870278
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 592139
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 450903
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 564687
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "66%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 269903
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "66%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 506551
+          },
+        ]
+      },
+      {
+        "ProcessName": "process",
+        "ProcessStatus": "Running",
+        "StartTime": "2022.02.21. 17:33:06",
+        "ProcessorUsage": "66%",
+        "PhysicalMemoryUsageBit": 61440000,
+        "PriorityLevel": "low",
+        "VirtualMemorySize": 54136,
+        "PID": 175961,
+        "Children": [
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 488794
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 615836
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 991265
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 886867
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 998430
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 592674
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 966809
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "66%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 350995
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "15%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 286853
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 204536
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "10%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 282579
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 630076
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 372146
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "20%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 725744
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 545029
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "15%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 288548
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 350335
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "20%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 997941
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 939233
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 718808
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "15%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 365084
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "20%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 541209
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 711986
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Stopped",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "50%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 690447
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 328295
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 163157
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "medium",
+            "VirtualMemorySize": 54136,
+            "PID": 969789
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 485312
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "80%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 889832
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Failed",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "50%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "high",
+            "VirtualMemorySize": 54136,
+            "PID": 755186
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "20%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 143109
+          },
+          {
+            "ProcessName": "process",
+            "ProcessStatus": "Running",
+            "StartTime": "2022.02.21. 17:33:06",
+            "ProcessorUsage": "20%",
+            "PhysicalMemoryUsageBit": 61440000,
+            "PriorityLevel": "low",
+            "VirtualMemorySize": 54136,
+            "PID": 152350
+          },
+        ]
+      },
+      {
+        "ProcessName": "process",
+        "ProcessStatus": "Running",
+        "StartTime": "2022.02.21. 17:33:06",
+        "ProcessorUsage": "50%",
+        "PhysicalMemoryUsageBit": 61440000,
+        "PriorityLevel": "high",
+        "VirtualMemorySize": 54136,
+        "PID": 755582
+      },
+      {
+        "ProcessName": "process",
+        "ProcessStatus": "Running",
+        "StartTime": "2022.02.21. 17:33:06",
+        "ProcessorUsage": "50%",
+        "PhysicalMemoryUsageBit": 61440000,
+        "PriorityLevel": "low",
+        "VirtualMemorySize": 54136,
+        "PID": 799775
+      }
+    ]
+  };
+  // tslint:disable
+  


### PR DESCRIPTION
Adding back mock processes to benefit the upcoming frontend rewrite.
We'll create a new frontend project the commented out code is for reference only.