### PR TITLE
Enable Central Package Management for dotnet projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,8 @@
 <Project>
-    <Import Project="../Directory.Build.props" Condition="Exists('../Directory.Build.props')" />
+    <Import
+        Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"
+        Condition="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''"
+    />
 
     <PropertyGroup>
         <ComposeUIRepositoryRoot>$(MSBuildThisFileDirectory.TrimEnd('/').TrimEnd('\'))</ComposeUIRepositoryRoot>

--- a/build/dotnet-pack.ps1
+++ b/build/dotnet-pack.ps1
@@ -11,5 +11,5 @@ foreach ($sln in GetSolutions) {
 }
 
 if ($failedSolutions.count -gt 0) {
-    throw "Build FAILED for solutions $failedSolutions"
+    throw "Pack FAILED for solutions $failedSolutions"
 }

--- a/build/dotnet-test.ps1
+++ b/build/dotnet-test.ps1
@@ -11,5 +11,5 @@ foreach ($sln in GetSolutions) {
 }
 
 if ($failedSolutions.count -gt 0) {
-    throw "Build FAILED for solutions $failedSolutions"
+    throw "Tests FAILED for solutions $failedSolutions"
 }

--- a/prototypes/multi-module-prototype/examples/multi-module-example/ComposeUI.Example.DataService/ComposeUI.Example.DataService.csproj
+++ b/prototypes/multi-module-prototype/examples/multi-module-example/ComposeUI.Example.DataService/ComposeUI.Example.DataService.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-	<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+	<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
 	<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
   </ItemGroup>
 

--- a/prototypes/multi-module-prototype/examples/multi-module-example/ComposeUI.Example.WPFDataGrid.TestApp/WPFDataGrid.TestApp.csproj
+++ b/prototypes/multi-module-prototype/examples/multi-module-example/ComposeUI.Example.WPFDataGrid.TestApp/WPFDataGrid.TestApp.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Serilog" Version="2.11.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />

--- a/prototypes/multi-module-prototype/examples/multi-module-example/ComposeUI.Example.WPFDataGrid/WPFDataGrid.csproj
+++ b/prototypes/multi-module-prototype/examples/multi-module-example/ComposeUI.Example.WPFDataGrid/WPFDataGrid.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Abstractions/MorganStanley.ComposeUI.ProcessExplorer.Abstractions.csproj
+++ b/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Abstractions/MorganStanley.ComposeUI.ProcessExplorer.Abstractions.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
     <PackageReference Include="System.Reactive" Version="6.0.0" />

--- a/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Client/MorganStanley.ComposeUI.ProcessExplorer.Client.csproj
+++ b/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Client/MorganStanley.ComposeUI.ProcessExplorer.Client.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Grpc" Version="2.46.6" />
     <PackageReference Include="Grpc.Net.Client" Version="2.53.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,3 +1,10 @@
 <Project>
-   <Import Project="../Directory.Build.props" Condition="Exists('../Directory.Build.props')"/>
+	<Import
+        Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"
+        Condition="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''"
+    />
+
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	</PropertyGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,32 @@
+﻿<Project>
+	<ItemGroup>
+		<PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.2.1" />
+		<PackageVersion Include="coverlet.collector" Version="3.1.2" />
+		<PackageVersion Include="FluentAssertions.Json" Version="6.1.0" />
+		<PackageVersion Include="FluentAssertions" Version="6.11.0" />
+		<PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.4.0" />
+		<PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+		<PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+		<PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
+		<PackageVersion Include="Microsoft.Extensions.Options" Version="6.0.0" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.1901.177" />
+		<PackageVersion Include="Moq" Version="4.18.4" />
+		<PackageVersion Include="MorganStanley.Fdc3" Version="2.0.0-alpha.5" />
+		<PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
+		<PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
+		<PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+		<PackageVersion Include="System.IO.Pipelines" Version="6.0.3" />
+		<PackageVersion Include="System.Net.Http" Version="4.3.4" />
+		<PackageVersion Include="System.Reactive.Async" Version="6.0.0-alpha.18" />
+		<PackageVersion Include="System.Reactive" Version="6.0.0" />
+		<PackageVersion Include="System.Text.Json" Version="6.0.8" />
+		<PackageVersion Include="Xunit.Combinatorial" Version="1.5.25" />
+		<PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+		<PackageVersion Include="xunit" Version="2.4.2" />
+	</ItemGroup>
+</Project>

--- a/src/fdc3/dotnet/DesktopAgent/Directory.Build.props
+++ b/src/fdc3/dotnet/DesktopAgent/Directory.Build.props
@@ -1,3 +1,0 @@
-<Project>
-	<Import Project="../Directory.Build.props" Condition="Exists('../Directory.Build.props')" />
-</Project>

--- a/src/fdc3/dotnet/DesktopAgent/src/DesktopAgent/DesktopAgent.csproj
+++ b/src/fdc3/dotnet/DesktopAgent/src/DesktopAgent/DesktopAgent.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
-    <PackageReference Include="MorganStanley.Fdc3" Version="2.0.0-alpha.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="MorganStanley.Fdc3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/fdc3/dotnet/DesktopAgent/src/DesktopAgent/Directory.Build.props
+++ b/src/fdc3/dotnet/DesktopAgent/src/DesktopAgent/Directory.Build.props
@@ -1,3 +1,0 @@
-<Project>
-	<Import Project="../Directory.Build.props" Condition="Exists('../Directory.Build.props')" />
-</Project>

--- a/src/fdc3/dotnet/DesktopAgent/src/Directory.Build.props
+++ b/src/fdc3/dotnet/DesktopAgent/src/Directory.Build.props
@@ -1,5 +1,8 @@
 <Project>
-    <Import Project="../Directory.Build.props" Condition="Exists('../Directory.Build.props')" />
+    <Import
+        Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"
+        Condition="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''"
+    />
 
     <ItemGroup>
         <InternalsVisibleTo Include="$(AssemblyName).Tests"/>

--- a/src/fdc3/dotnet/DesktopAgent/tests/DesktopAgent.Tests/DesktopAgent.Tests.csproj
+++ b/src/fdc3/dotnet/DesktopAgent/tests/DesktopAgent.Tests/DesktopAgent.Tests.csproj
@@ -13,17 +13,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/messaging/Directory.Build.props
+++ b/src/messaging/Directory.Build.props
@@ -1,3 +1,0 @@
-<Project>
-	<Import Project="../Directory.Build.props" Condition="Exists('../Directory.Build.props')" />
-</Project>

--- a/src/messaging/dotnet/Directory.Build.props
+++ b/src/messaging/dotnet/Directory.Build.props
@@ -1,5 +1,8 @@
 <Project>
-	<Import Project="../Directory.Build.props" Condition="Exists('../Directory.Build.props')" />
+	<Import
+        Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"
+        Condition="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''"
+    />
 
 	<PropertyGroup>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/src/messaging/dotnet/examples/TestServer/TestServer.csproj
+++ b/src/messaging/dotnet/examples/TestServer/TestServer.csproj
@@ -8,8 +8,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/messaging/dotnet/src/Client/MorganStanley.ComposeUI.Messaging.Client.csproj
+++ b/src/messaging/dotnet/src/Client/MorganStanley.ComposeUI.Messaging.Client.csproj
@@ -12,14 +12,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.4.0" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
-	  <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-	  <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
-	  <PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
-	  <PackageReference Include="System.Reactive" Version="6.0.0" />
-	  <PackageReference Include="System.Reactive.Async" Version="6.0.0-alpha.18" />
+	  <PackageReference Include="Microsoft.CodeAnalysis.Common" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+	  <PackageReference Include="Microsoft.Extensions.Options" />
+	  <PackageReference Include="Nito.AsyncEx" />
+	  <PackageReference Include="System.IO.Pipelines" />
+	  <PackageReference Include="System.Reactive" />
+	  <PackageReference Include="System.Reactive.Async" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/messaging/dotnet/src/Core/MorganStanley.ComposeUI.Messaging.Core.csproj
+++ b/src/messaging/dotnet/src/Core/MorganStanley.ComposeUI.Messaging.Core.csproj
@@ -14,10 +14,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.1" />
-		<PackageReference Include="System.Reactive" Version="6.0.0" />
-		<PackageReference Include="System.Reactive.Async" Version="6.0.0-alpha.18" />
-		<PackageReference Include="System.Text.Json" Version="6.0.8" />
+		<PackageReference Include="CommunityToolkit.HighPerformance" />
+		<PackageReference Include="System.Reactive" />
+		<PackageReference Include="System.Reactive.Async" />
+		<PackageReference Include="System.Text.Json" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/messaging/dotnet/src/Directory.Build.props
+++ b/src/messaging/dotnet/src/Directory.Build.props
@@ -1,5 +1,8 @@
 <Project>
-	<Import Project="../Directory.Build.props" Condition="Exists('../Directory.Build.props')" />
+	<Import
+        Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"
+        Condition="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''"
+    />
 
 	<ItemGroup>
 		<InternalsVisibleTo Include="$(AssemblyName).Tests"/>

--- a/src/messaging/dotnet/src/Server/MorganStanley.ComposeUI.Messaging.Server.csproj
+++ b/src/messaging/dotnet/src/Server/MorganStanley.ComposeUI.Messaging.Server.csproj
@@ -8,12 +8,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-		<PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
-		<PackageReference Include="System.Text.Json" Version="6.0.8" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Options" />
+		<PackageReference Include="System.IO.Pipelines" />
+		<PackageReference Include="System.Text.Json" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/messaging/dotnet/test/Directory.Build.props
+++ b/src/messaging/dotnet/test/Directory.Build.props
@@ -1,21 +1,24 @@
 <Project>
-	<Import Project="../Directory.Build.props" Condition="Exists('../Directory.Build.props')" />
+	<Import
+        Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"
+        Condition="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')) != ''"
+    />
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.7.0" />
-		<PackageReference Include="FluentAssertions.Json" Version="6.1.0" />
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="FluentAssertions" />
+		<PackageReference Include="FluentAssertions.Json" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Moq" Version="4.18.1" />
-		<PackageReference Include="coverlet.collector" Version="3.1.2">
+		<PackageReference Include="Moq" />
+		<PackageReference Include="coverlet.collector">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Xunit.Combinatorial" Version="1.5.25" />
+		<PackageReference Include="Xunit.Combinatorial" />
 	</ItemGroup>
 </Project>

--- a/src/messaging/dotnet/test/IntegrationTests/MorganStanley.ComposeUI.Messaging.IntegrationTests.csproj
+++ b/src/messaging/dotnet/test/IntegrationTests/MorganStanley.ComposeUI.Messaging.IntegrationTests.csproj
@@ -7,8 +7,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" />
+		<PackageReference Include="Newtonsoft.Json" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/messaging/dotnet/test/Server.Tests/MorganStanley.ComposeUI.Messaging.Server.Tests.csproj
+++ b/src/messaging/dotnet/test/Server.Tests/MorganStanley.ComposeUI.Messaging.Server.Tests.csproj
@@ -7,9 +7,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" />
+		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="System.Net.Http" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/shared/dotnet/MorganStanley.ComposeUI.Testing/MorganStanley.ComposeUI.Testing.csproj
+++ b/src/shared/dotnet/MorganStanley.ComposeUI.Testing/MorganStanley.ComposeUI.Testing.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
+    <PackageReference Include="Nito.AsyncEx.Coordination" />
   </ItemGroup>
 
 </Project>

--- a/src/shell/dotnet/Shell/Shell.csproj
+++ b/src/shell/dotnet/Shell/Shell.csproj
@@ -16,9 +16,9 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1901.177" />
-		<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" />
+		<PackageReference Include="Microsoft.Web.WebView2" />
+		<PackageReference Include="System.CommandLine" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -54,17 +54,13 @@
 		<EmbeddedResource Include="$(Fdc3BundleOutput)" />
 	</ItemGroup>
 
-	<Target Name="InstallMonoRepoDependencies"
-		Condition="!Exists('$(ComposeUIRepositoryRoot)\node_modules')">
+	<Target Name="InstallMonoRepoDependencies" Condition="!Exists('$(ComposeUIRepositoryRoot)\node_modules')">
 		<Message Importance="high" Text="Installing node_modules..." />
 		<Exec Command="cd $(ComposeUIRepositoryRoot) &amp;&amp; npm install" />
 		<Message Importance="normal" Text="Finished command: npm install." />
 	</Target>
 
-	<Target
-		Name="BuildComposeUIFdc3Bundle"
-		BeforeTargets="PrebuildEvent"
-		Condition="!Exists('$(Fdc3BundleOutput)')">
+	<Target Name="BuildComposeUIFdc3Bundle" BeforeTargets="PrebuildEvent" Condition="!Exists('$(Fdc3BundleOutput)')">
 		<CallTarget Targets="InstallMonoRepoDependencies" />
 		<Exec Command="cd $(ComposeUIRepositoryRoot) &amp;&amp; npx lerna run build --scope @morgan-stanley/composeui-fdc3" />
 		<Message Importance="normal" Text="Finished building the fdc3 bundle." />

--- a/src/shell/dotnet/tests/Shell.Tests/Shell.Tests.csproj
+++ b/src/shell/dotnet/tests/Shell.Tests/Shell.Tests.csproj
@@ -9,13 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
- Enable Central Package Management for dotnet projects
- Remove unnecessary Directory.Build.props files and use MSBuild function to import the correct file from above