### PR TITLE
feat(process-explorer/frontend): Add sort to column headers

### DIFF
--- a/prototypes/process-explorer/oss-frontend/src/app/app.module.ts
+++ b/prototypes/process-explorer/oss-frontend/src/app/app.module.ts
@@ -12,7 +12,7 @@ import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatTableModule } from '@angular/material/table';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatMenuModule } from '@angular/material/menu';
-
+import { MatSortModule } from '@angular/material/sort';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -38,7 +38,8 @@ import { ProcessesComponent } from './components/processes/processes.component';
     MatPaginatorModule,
     MatTableModule,
     MatExpansionModule,
-    MatMenuModule
+    MatMenuModule,
+    MatSortModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/prototypes/process-explorer/oss-frontend/src/app/components/processes/processes.component.html
+++ b/prototypes/process-explorer/oss-frontend/src/app/components/processes/processes.component.html
@@ -4,7 +4,7 @@
 
     <mat-table #table [dataSource]="dataSource" matSort (matSortChange)="announceSortChange($event)" multiTemplateDataRows>
     <ng-container *ngFor="let column of displayedColumns" matColumnDef="{{column.key}}" >
-      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by {{column.header}}"> {{column.header}} </th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header> {{column.header}} </th>
       <td mat-cell *matCellDef="let element"> {{element[column.key]}} </td>
     </ng-container>
   

--- a/prototypes/process-explorer/oss-frontend/src/app/components/processes/processes.component.html
+++ b/prototypes/process-explorer/oss-frontend/src/app/components/processes/processes.component.html
@@ -2,9 +2,9 @@
 <h1 class="header">Processes</h1>
 <div class="table-all mat-elevation-z8" >
 
-    <mat-table #table [dataSource]="dataSource" multiTemplateDataRows>
+    <mat-table #table [dataSource]="dataSource" matSort (matSortChange)="announceSortChange($event)" multiTemplateDataRows>
     <ng-container *ngFor="let column of displayedColumns" matColumnDef="{{column.key}}" >
-      <th mat-header-cell *matHeaderCellDef> {{column.header}} </th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header sortActionDescription="Sort by {{column.header}}"> {{column.header}} </th>
       <td mat-cell *matCellDef="let element"> {{element[column.key]}} </td>
     </ng-container>
   

--- a/prototypes/process-explorer/oss-frontend/src/app/components/processes/processes.component.scss
+++ b/prototypes/process-explorer/oss-frontend/src/app/components/processes/processes.component.scss
@@ -82,3 +82,7 @@
   .element-description-attribution {
     opacity: 0.5;
   }
+
+  th.mat-sort-header-sorted {
+    color: black;
+  }

--- a/prototypes/process-explorer/oss-frontend/src/app/components/processes/processes.component.spec.ts
+++ b/prototypes/process-explorer/oss-frontend/src/app/components/processes/processes.component.spec.ts
@@ -15,7 +15,11 @@ describe('ProcessesComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ProcessesComponent],
-      imports: [MatPaginatorModule, MatToolbarModule, MatTableModule, BrowserAnimationsModule]
+      imports: [
+        MatPaginatorModule, 
+        MatToolbarModule, 
+        MatTableModule, 
+        BrowserAnimationsModule]
     });
     fixture = TestBed.createComponent(ProcessesComponent);
     component = fixture.componentInstance;

--- a/prototypes/process-explorer/oss-frontend/src/app/components/processes/processes.component.ts
+++ b/prototypes/process-explorer/oss-frontend/src/app/components/processes/processes.component.ts
@@ -5,7 +5,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { ProcessInfo, ProcessTable } from 'src/app/DTOs/ProcessInfo';
 import { ProcessesService } from 'src/app/services/processes.service';
 import { animate, state, style, transition, trigger } from '@angular/animations';
-import { MatSort, Sort } from '@angular/material/sort';
+import { MatSort, Sort,  } from '@angular/material/sort';
 import {LiveAnnouncer} from '@angular/cdk/a11y';
 
 
@@ -32,7 +32,7 @@ export class ProcessesComponent implements AfterViewInit {
   @ViewChild(MatPaginator) paginator: MatPaginator;
   @ViewChild(MatSort) sort: MatSort;
 
-  constructor(private processService: ProcessesService, private _liveAnnouncer: LiveAnnouncer) {
+  constructor(private processService: ProcessesService, private liveAnnouncer: LiveAnnouncer) {
     this.processService.getProcesses('Processes').subscribe(process => this.processesData = process);
     this.displayedColumnsKeys = this.displayedColumns.map(column => column.key);
     this.dataSource = new MatTableDataSource<ProcessTable>(this.processesData);
@@ -55,9 +55,9 @@ export class ProcessesComponent implements AfterViewInit {
 
   announceSortChange(sortState: Sort) {
     if (sortState.direction) {
-      this._liveAnnouncer.announce(`Sorted ${sortState.direction}ending`);
+      this.liveAnnouncer.announce(`Sorted ${sortState.direction}ending`);
     } else {
-      this._liveAnnouncer.announce('Sorting cleared');
+      this.liveAnnouncer.announce('Sorting cleared');
     }
   }
 }

--- a/prototypes/process-explorer/oss-frontend/src/app/components/processes/processes.component.ts
+++ b/prototypes/process-explorer/oss-frontend/src/app/components/processes/processes.component.ts
@@ -5,7 +5,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { ProcessInfo, ProcessTable } from 'src/app/DTOs/ProcessInfo';
 import { ProcessesService } from 'src/app/services/processes.service';
 import { animate, state, style, transition, trigger } from '@angular/animations';
-import { MatSort, Sort,  } from '@angular/material/sort';
+import { MatSort, Sort } from '@angular/material/sort';
 import {LiveAnnouncer} from '@angular/cdk/a11y';
 
 

--- a/prototypes/process-explorer/oss-frontend/src/app/components/processes/processes.component.ts
+++ b/prototypes/process-explorer/oss-frontend/src/app/components/processes/processes.component.ts
@@ -5,6 +5,8 @@ import { MatTableDataSource } from '@angular/material/table';
 import { ProcessInfo, ProcessTable } from 'src/app/DTOs/ProcessInfo';
 import { ProcessesService } from 'src/app/services/processes.service';
 import { animate, state, style, transition, trigger } from '@angular/animations';
+import { MatSort, Sort } from '@angular/material/sort';
+import {LiveAnnouncer} from '@angular/cdk/a11y';
 
 
 @Component({
@@ -28,8 +30,9 @@ export class ProcessesComponent implements AfterViewInit {
   displayedColumnsKeys: string[];
 
   @ViewChild(MatPaginator) paginator: MatPaginator;
+  @ViewChild(MatSort) sort: MatSort;
 
-  constructor(private processService: ProcessesService) {
+  constructor(private processService: ProcessesService, private _liveAnnouncer: LiveAnnouncer) {
     this.processService.getProcesses('Processes').subscribe(process => this.processesData = process);
     this.displayedColumnsKeys = this.displayedColumns.map(column => column.key);
     this.dataSource = new MatTableDataSource<ProcessTable>(this.processesData);
@@ -37,6 +40,7 @@ export class ProcessesComponent implements AfterViewInit {
 
   ngAfterViewInit() {
     this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
   }
   ngOnInit() {
   }
@@ -47,6 +51,14 @@ export class ProcessesComponent implements AfterViewInit {
 
   onItemSelected(idx: number) {
     console.log(idx);
+  }
+
+  announceSortChange(sortState: Sort) {
+    if (sortState.direction) {
+      this._liveAnnouncer.announce(`Sorted ${sortState.direction}ending`);
+    } else {
+      this._liveAnnouncer.announce('Sorting cleared');
+    }
   }
 }
 


### PR DESCRIPTION
Changes in this PR:
Processes View: Processes can be sorted by clicking on the table column headers.