### PR TITLE
feat(preloading-scripts): Adding IPreloadScriptPolicy with default implementation for preloading scripts on allowed webpages

### DIFF
--- a/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader.Abstractions/WebStartupProperties.cs
+++ b/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader.Abstractions/WebStartupProperties.cs
@@ -20,6 +20,7 @@ public sealed class WebStartupProperties
 {
     public Uri Url { get; set; } = ModuleLoaderConstants.DefaultUri;
     public Uri? IconUrl { get; set; }
+    public List<Uri>? AllowedOrigins { get; set; }
     public List<WebModuleScriptProvider> ScriptProviders { get; } = new();
 }
 

--- a/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader/Runners/WebModuleRunner.cs
+++ b/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader/Runners/WebModuleRunner.cs
@@ -20,7 +20,7 @@ internal class WebModuleRunner : IModuleRunner
     {
         if (startupContext.ModuleInstance.Manifest.TryGetDetails(out WebManifestDetails details))
         {
-            startupContext.AddProperty(new WebStartupProperties { IconUrl = details.IconUrl, Url = details.Url });
+            startupContext.AddProperty(new WebStartupProperties { IconUrl = details.IconUrl, Url = details.Url, AllowedOrigins = details.AllowedOrigins });
         }
 
         await pipeline();

--- a/src/shell/dotnet/Shell/MainWindow.xaml.cs
+++ b/src/shell/dotnet/Shell/MainWindow.xaml.cs
@@ -12,14 +12,11 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Windows;
 using System.Windows.Controls.Ribbon;
-using System.Windows.Documents;
 using CommunityToolkit.Mvvm.ComponentModel;
 using MorganStanley.ComposeUI.ModuleLoader;
 using MorganStanley.ComposeUI.Shell.ImageSource;
-using MorganStanley.ComposeUI.Shell.Modules;
 
 namespace MorganStanley.ComposeUI.Shell;
 
@@ -66,8 +63,6 @@ public partial class MainWindow : RibbonWindow
         get => (MainWindowViewModel) DataContext;
         private set => DataContext = value;
     }
-
-
 
     private async void StartModule_Click(object sender, RoutedEventArgs e)
     {

--- a/src/shell/dotnet/Shell/Preloading/DefaultPreloadScriptPolicy.cs
+++ b/src/shell/dotnet/Shell/Preloading/DefaultPreloadScriptPolicy.cs
@@ -1,0 +1,56 @@
+﻿// Morgan Stanley makes this available to you under the Apache License,
+// Version 2.0 (the "License"). You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0.
+// 
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership. Unless required by applicable law or agreed
+// to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions
+// and limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MorganStanley.ComposeUI.ModuleLoader;
+
+namespace MorganStanley.ComposeUI.Shell.Preloading;
+
+internal sealed class DefaultPreloadScriptPolicy : IPreloadScriptPolicy
+{
+    private readonly IEnumerable<Uri> _allowedOrigins = Enumerable.Empty<Uri>();
+
+    public DefaultPreloadScriptPolicy(IModuleInstance? moduleInstance)
+    {
+        if (moduleInstance == null)
+            return;
+
+        var webProperties = moduleInstance.GetProperties().OfType<WebStartupProperties>().FirstOrDefault();
+        if (webProperties != null)
+        {
+            _allowedOrigins = webProperties.AllowedOrigins ?? Enumerable.Empty<Uri>();
+        }
+    }
+
+    public Task<bool> IsPreloadingScriptsAllowedAsync(Uri uri, Uri appUri)
+    {
+        if (uri.IsBaseOf(appUri))
+        {
+            return Task.FromResult(true);
+        }
+
+        if (appUri.GetLeftPart(UriPartial.Authority) == uri.GetLeftPart(UriPartial.Authority))
+        {
+            return Task.FromResult(true);
+        }
+
+        if (_allowedOrigins.Contains(appUri))
+        {
+            return Task.FromResult(true);
+        }
+
+        return Task.FromResult(false);
+    }
+}

--- a/src/shell/dotnet/Shell/Preloading/IPreloadScriptPolicy.cs
+++ b/src/shell/dotnet/Shell/Preloading/IPreloadScriptPolicy.cs
@@ -10,25 +10,18 @@
 // or implied. See the License for the specific language governing permissions
 // and limitations under the License.
 
-namespace MorganStanley.ComposeUI.ModuleLoader;
+using System;
+using System.Threading.Tasks;
 
-/// <summary>
-/// Contains the manifest details for web modules.
-/// </summary>
-/// <remarks>
-/// Web modules should have <see cref="ModuleType.Web"/> as their <see cref="IModuleManifest.ModuleType"/>
-/// </remarks>
-public sealed class WebManifestDetails
+namespace MorganStanley.ComposeUI.Shell.Preloading;
+
+public interface IPreloadScriptPolicy
 {
     /// <summary>
-    /// The URL to open when this module is started.
+    /// Validates if the url is allowed for preloading scripts by checking the base <seealso cref="WebWindow"/>'s url with the url where it should be navigated.
     /// </summary>
-    public Uri Url { get; init; } = ModuleLoaderConstants.DefaultUri;
-
-    /// <summary>
-    /// The URL of the window icon, if any.
-    /// </summary>
-    public Uri? IconUrl { get; init; }
-
-    public List<Uri>? AllowedOrigins { get; init; }
+    /// <param name="uri"><seealso cref="Uri"/> of the base <seealso cref="WebWindow"/>.</param>
+    /// <param name="appUri"><seealso cref="Uri"/> of the <seealso cref="WebWindow"/> where the app should be navigated.</param>
+    /// <returns></returns>
+    Task<bool> IsPreloadingScriptsAllowedAsync(Uri uri, Uri appUri);
 }

--- a/src/shell/dotnet/Shell/Shell.csproj
+++ b/src/shell/dotnet/Shell/Shell.csproj
@@ -15,6 +15,10 @@
 		<None Remove="MainWindow.xaml" />
 		<None Remove="WebWindow.xaml" />
 	</ItemGroup>
+
+	<ItemGroup>
+		<InternalsVisibleTo Include="Shell.Tests" />	
+	</ItemGroup>
 	
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" />

--- a/src/shell/dotnet/Shell/WebWindow.xaml.cs
+++ b/src/shell/dotnet/Shell/WebWindow.xaml.cs
@@ -1,4 +1,16 @@
-﻿using System;
+﻿// Morgan Stanley makes this available to you under the Apache License,
+// Version 2.0 (the "License"). You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0.
+// 
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership. Unless required by applicable law or agreed
+// to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions
+// and limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -12,7 +24,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Web.WebView2.Core;
 using MorganStanley.ComposeUI.ModuleLoader;
 using MorganStanley.ComposeUI.Shell.ImageSource;
-using MorganStanley.ComposeUI.Shell.Utilities;
+using MorganStanley.ComposeUI.Shell.Preloading;
 
 namespace MorganStanley.ComposeUI.Shell;
 
@@ -26,12 +38,14 @@ public partial class WebWindow : Window
         IModuleLoader moduleLoader,
         IModuleInstance? moduleInstance = null,
         ILogger<WebWindow>? logger = null,
-        IImageSourcePolicy? imageSourcePolicy = null)
+        IImageSourcePolicy? imageSourcePolicy = null,
+        IPreloadScriptPolicy? preloadScriptPolicy = null)
     {
         _moduleLoader = moduleLoader;
         _moduleInstance = moduleInstance;
         _iconProvider = new ImageSourceProvider(imageSourcePolicy ?? new DefaultImageSourcePolicy());
         _options = options;
+        _preloadScriptPolicy = preloadScriptPolicy ?? new DefaultPreloadScriptPolicy(moduleInstance);
         _logger = logger ?? NullLogger<WebWindow>.Instance;
         InitializeComponent();
 
@@ -106,6 +120,7 @@ public partial class WebWindow : Window
     private readonly IModuleLoader _moduleLoader;
     private readonly IModuleInstance? _moduleInstance;
     private readonly WebWindowOptions _options;
+    private readonly IPreloadScriptPolicy _preloadScriptPolicy;
     private readonly ILogger<WebWindow> _logger;
     private readonly ImageSourceProvider _iconProvider;
     private bool _scriptsInjected;
@@ -162,7 +177,17 @@ public partial class WebWindow : Window
         Dispatcher.InvokeAsync(
             async () =>
             {
-                await InjectScriptsAsync(WebView.CoreWebView2);
+                var webProperties = _moduleInstance?.GetProperties().OfType<WebStartupProperties>().FirstOrDefault();
+                if (webProperties?.Url != null 
+                    && await _preloadScriptPolicy.IsPreloadingScriptsAllowedAsync(webProperties.Url, new Uri(args.Uri)))
+                {
+                    await InjectScriptsAsync(WebView.CoreWebView2);
+                }
+                else
+                {
+                    _scriptsInjected = true;
+                    _scriptInjectionCompleted.SetResult();
+                }
 
                 WebView.CoreWebView2.Navigate(args.Uri);
             });
@@ -202,7 +227,7 @@ public partial class WebWindow : Window
         using var deferral = e.GetDeferral();
         e.Handled = true;
 
-        var windowOptions = new WebWindowOptions {Url = e.Uri};
+        var windowOptions = new WebWindowOptions { Url = e.Uri };
 
         if (e.WindowFeatures.HasSize)
         {
@@ -210,7 +235,7 @@ public partial class WebWindow : Window
             windowOptions.Height = e.WindowFeatures.Height;
         }
 
-        var constructorArgs = new List<object> {windowOptions};
+        var constructorArgs = new List<object> { windowOptions };
 
         // For now, we only inject the module-specific information when the window was created 
         // in response to a start request. Later we might allow the page to open a new window

--- a/src/shell/dotnet/Shell/WebWindowOptions.cs
+++ b/src/shell/dotnet/Shell/WebWindowOptions.cs
@@ -1,4 +1,16 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿// Morgan Stanley makes this available to you under the Apache License,
+// Version 2.0 (the "License"). You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0.
+// 
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership. Unless required by applicable law or agreed
+// to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions
+// and limitations under the License.
+
+using System.ComponentModel.DataAnnotations;
 
 namespace MorganStanley.ComposeUI.Shell;
 

--- a/src/shell/dotnet/Shell/appsettings.json
+++ b/src/shell/dotnet/Shell/appsettings.json
@@ -5,7 +5,6 @@
       "MorganStanley.ComposeUI.Messaging": "Debug"
     }
   },
-
   "FDC3": {
     "EnableFdc3": true,
     "DesktopAgent": {

--- a/src/shell/dotnet/examples/module-catalog.json
+++ b/src/shell/dotnet/examples/module-catalog.json
@@ -32,7 +32,10 @@
         "ModuleType": "web",
         "Details": {
             "Url": "https://fdc3.finos.org/toolbox/fdc3-workbench/",
-            "IconUrl": "https://fdc3.finos.org/toolbox/fdc3-workbench/favicon.ico"
+            "IconUrl": "https://fdc3.finos.org/toolbox/fdc3-workbench/favicon.ico",
+            "AllowedOrigins": [
+                "https://www.google.com"
+            ]
         }
     }
 ]

--- a/src/shell/dotnet/tests/Shell.Tests/Preloading/DefaultPreloadScriptPolicyTests.cs
+++ b/src/shell/dotnet/tests/Shell.Tests/Preloading/DefaultPreloadScriptPolicyTests.cs
@@ -1,0 +1,87 @@
+﻿/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+using FluentAssertions;
+using Moq;
+using MorganStanley.ComposeUI.ModuleLoader;
+
+namespace MorganStanley.ComposeUI.Shell.Preloading;
+
+public class DefaultPreloadScriptPolicyTests
+{
+    private readonly Mock<IModuleInstance> _moduleInstanceMock;
+
+    public DefaultPreloadScriptPolicyTests()
+    {
+        var properties = new object[]
+        {
+            new WebStartupProperties()
+            {
+                AllowedOrigins = new List<Uri>()
+                {
+                    new("https://www.morganstanley.com/"),
+                    new("https://www.microsoft.com/"),
+                    new("https://www.google.com/")
+                }
+            }
+        };
+
+        _moduleInstanceMock = new Mock<IModuleInstance>();
+        
+        _moduleInstanceMock
+            .Setup(_ => _.GetProperties())
+            .Returns(properties);
+    }
+
+    [Theory]
+    [InlineData("https://www.github.com/", "https://www.github.com/morganstanley/ComposeUI")]
+    [InlineData("https://www.github.com", "https://www.github.com/")]
+    public async Task IsPreloadingScriptsAllowedAsync_returns_true_based_on_base_url(string baseAppUrl, string urlToNavigate)
+    {
+        var preloadPolicy = new DefaultPreloadScriptPolicy(_moduleInstanceMock.Object);
+        var result = await preloadPolicy.IsPreloadingScriptsAllowedAsync(
+            new Uri(baseAppUrl),
+            new Uri(urlToNavigate));
+
+        result.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("https://www.github.com", "https://www.microsoft.com/")]
+    [InlineData("https://www.github.com", "https://www.morganstanley.com/")]
+    [InlineData("https://www.github.com", "https://www.google.com/")]
+    [InlineData("https://www.github.com", "https://www.google.com")]
+    public async Task IsPreloadingScriptsAllowedAsync_returns_true_based_on_the_allowed_origins(string baseAppUrl, string urlToNavigate)
+    {
+        var preloadPolicy = new DefaultPreloadScriptPolicy(_moduleInstanceMock.Object);
+        var result = await preloadPolicy.IsPreloadingScriptsAllowedAsync(
+            new Uri(baseAppUrl),
+            new Uri(urlToNavigate));
+
+        result.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("https://www.github.com/", "http://www.github.com")]
+    [InlineData("https://www.github.com/", "http://www.morganstanley.com")]
+    public async Task IsPreloadingScriptsAllowedAsync_returns_false(string baseAppUrl, string urlToNavigate)
+    {
+        var preloadPolicy = new DefaultPreloadScriptPolicy(_moduleInstanceMock.Object);
+        var result = await preloadPolicy.IsPreloadingScriptsAllowedAsync(
+            new Uri(baseAppUrl),
+            new Uri(urlToNavigate));
+
+        result.Should().BeFalse();
+    }
+}

--- a/src/shell/dotnet/tests/Shell.Tests/Shell.Tests.csproj
+++ b/src/shell/dotnet/tests/Shell.Tests/Shell.Tests.csproj
@@ -1,28 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
-	<RootNamespace>MorganStanley.ComposeUI.Shell</RootNamespace>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0-windows</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<RootNamespace>MorganStanley.ComposeUI.Shell</RootNamespace>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="xunit" />
+		<PackageReference Include="xunit.runner.visualstudio">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Moq" />
+		<PackageReference Include="FluentAssertions" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Shell\Shell.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Shell\Shell.csproj" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Changes:
- Added IPreloadScriptPolicy with its default implementation which takes an IModuleInstance and gets its AllowedOrigins from its WebStartupProperties and validates -if it tries to navigate or open a window, that the preloading scripts is allowed or denied based on its parent base URI and allowed origins list.