### PR TITLE
fix(Examples/WPFDiagnosticsExample): Check if Executable Exists

### DIFF
--- a/src/shell/dotnet/Shell/MainWindow.xaml.cs
+++ b/src/shell/dotnet/Shell/MainWindow.xaml.cs
@@ -106,13 +106,25 @@ public partial class MainWindow : RibbonWindow
             }
             else if (manifest.TryGetDetails<NativeManifestDetails>(out var nativeManifestDetails))
             {
-                var icon = System.Drawing.Icon.ExtractAssociatedIcon(Path.GetFullPath(nativeManifestDetails.Path.ToString()));
-
-                ImageSource = System.Windows.Interop.Imaging.CreateBitmapSourceFromHIcon(
-                icon.Handle,
-                new Int32Rect { Width = icon.Width, Height = icon.Height },
-                BitmapSizeOptions.FromEmptyOptions());
+                var icon = GetNativeAppIcon(nativeManifestDetails);
+                if (icon != null) { 
+                    ImageSource = System.Windows.Interop.Imaging.CreateBitmapSourceFromHIcon(
+                    icon.Handle,
+                    new Int32Rect { Width = icon.Width, Height = icon.Height },
+                    BitmapSizeOptions.FromEmptyOptions());
+                }
             }
+        }
+
+        public System.Drawing.Icon? GetNativeAppIcon(NativeManifestDetails nativeManifestDetails) {
+
+           var path = Path.GetFullPath(nativeManifestDetails.Path.ToString());
+
+            if (!File.Exists(path))
+            {
+               return null;
+            }
+            return System.Drawing.Icon.ExtractAssociatedIcon(path);
         }
 
         public IModuleManifest Manifest { get; }


### PR DESCRIPTION
**Changes in this PR**
* Adding Error Handling for extracting the icon from a native app

README is updated in https://github.com/morganstanley/ComposeUI/pull/462 