### PR TITLE
Publishing Messaging nuget packages and some related CI streamlining

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,8 +23,8 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        dotnet-version: [ ${{ vars.DOTNET_VERSION }} ]
-        node-version: [ ${{ vars.NODE_VERSION }} ]
+        dotnet-version: [ '${{ vars.DOTNET_VERSION }}' ]
+        node-version: [ '${{ vars.NODE_VERSION }}' ]
     steps:
     - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
@@ -67,8 +67,17 @@ jobs:
       uses: codecov/codecov-action@54bcd8715eee62d40e33596ef5e8f0f48dbbccab # v4.1.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        
+    - name: Pack .NET
+      run: |
+           powershell ./build/dotnet-pack.ps1
 
-    # By uploading it's shared with the other workflows that are reusing this
+    - name: Upload Nuget Packages
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: packages
+        path: ${{ github.workspace }}/packages
+
     - name: Upload Shell Binaries
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,17 +2,18 @@
 
 # This workflow will do a clean install of node dependencies, build the source code and run tests
 
-name: CI
-
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
   workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: read
+
+name: CI
 
 jobs:
   build:
@@ -22,8 +23,8 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        dotnet-version: [ '6.0.x' ]
-        node-version: [ '18.x' ]
+        dotnet-version: [ ${{ vars.DOTNET_VERSION }} ]
+        node-version: [ ${{ vars.NODE_VERSION }} ]
     steps:
     - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
@@ -49,47 +50,17 @@ jobs:
 
     - name: Install NuGet dependencies
       run: |
-        $failedSolutions = @()
-        
-        Get-ChildItem -Recurse -Include *.sln `
-        | ForEach-Object {
-            dotnet restore $_;
-            if ($LASTEXITCODE -ne 0) {$failedSolutions += Split-Path $_ -leaf; }
-          }
-        
-        if ($failedSolutions.count -gt 0) {
-            throw "Restore FAILED for solutions $failedSolutions"
-        }
+           powershell ./build/dotnet-restore.ps1
 
 
     - name: Build .NET
       run: |
-        $failedSolutions = @()
-        
-        Get-ChildItem -Recurse -Include *.sln `
-        | ForEach-Object {
-            dotnet build $_ --configuration Release --no-restore; 
-            if ($LASTEXITCODE -ne 0) {$failedSolutions += Split-Path $_ -leaf; }
-          }
-        
-        if ($failedSolutions.count -gt 0) {
-            throw "Build FAILED for solutions $failedSolutions"
-        }
+           powershell ./build/dotnet-build.ps1
 
 
     - name: Test .NET
       run: |
-        $failedSolutions = @()
-        
-        Get-ChildItem -Recurse -Include *.sln `
-        | ForEach-Object {
-            dotnet test $_ --configuration Release --no-build; 
-            if ($LASTEXITCODE -ne 0) { $failedSolutions += Split-Path $_ -leaf; }
-        }
-        
-        if ($failedSolutions.count -gt 0) {
-            throw "Test FAILED for solutions $failedSolutions"
-        }
+           powershell ./build/dotnet-test.ps1
 
 
     - name: Codecov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
     name: Upload Release Asset
     needs: build
     runs-on: windows-latest
-
     steps:
 
       # Using shared artifact from build workflow
@@ -37,7 +36,7 @@ jobs:
         run: Compress-Archive -Path  ${{ github.workspace }}/shell-binaries/* composeui-${{ github.ref_name }}-win32.zip
         
       - name: Upload Release Asset
-        id: upload-release-asset 
+        id: upload-release-asset
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,7 +54,7 @@ jobs:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 18
+          node-version: ${{ vars.NODE_VERSION }}
           registry-url: https://registry.npmjs.org/
       - run: |
              dir
@@ -64,5 +63,28 @@ jobs:
              npm whoami
              npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: ${{ github.workspace }}/src/shell/js/composeui-node-launcher/
+
+  deploy_to_nuget:
+    name: Publish messaging packages to nuget.org
+    runs-on: windows-latest
+    needs: build
+    env:
+      nuget_source: https://api.nuget.org/v3/index.json
+    steps:
+      - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        with:
+          name: packages
+          path: ./packages
+      - uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
+        with:
+          dotnet-version: ${{ vars.DOTNET_VERSION }}
+      - name: Publish Messaging packages
+        working-directory: ./packages
+        run: |
+             dotnet nuget push MorganStanley.ComposeUI.Messaging.Core.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source ${{ env.nuget_source }} --skip-duplicate
+             dotnet nuget push MorganStanley.ComposeUI.Messaging.Server.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source ${{ env.nuget_source }} --skip-duplicate
+             dotnet nuget push MorganStanley.ComposeUI.Messaging.Client.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source ${{ env.nuget_source }} --skip-duplicate
+             dotnet nuget push MorganStanley.ComposeUI.Messaging.Host.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source ${{ env.nuget_source }} --skip-duplicate
+

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,4 +14,10 @@
         <VSTestLogger>trx</VSTestLogger>
         <VSTestResultsDirectory>$(ComposeUIRepositoryRoot)/artifacts/test-results</VSTestResultsDirectory>
     </PropertyGroup>
+    
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <VersionPrefix>0.1.0</VersionPrefix>
+        <VersionSuffix>alpha.3</VersionSuffix>
+    </PropertyGroup>
 </Project>

--- a/build/dotnet-pack.ps1
+++ b/build/dotnet-pack.ps1
@@ -3,7 +3,7 @@
 $failedSolutions = @()
 
 foreach ($sln in GetSolutions) {
-    dotnet pack $sln --configuration Release --no-build
+    dotnet pack $sln --configuration Release --no-build --output ./packages
     
     if ($LASTEXITCODE -ne 0 ) { 
         $failedSolutions += $sln

--- a/build/dotnet-test.ps1
+++ b/build/dotnet-test.ps1
@@ -3,7 +3,7 @@
 $failedSolutions = @()
 
 foreach ($sln in GetSolutions) {
-    dotnet test $sln --no-restore --verbosity normal --collect:"XPlat Code Coverage"
+    dotnet test $sln --no-build --configuration Release --verbosity normal --collect:"XPlat Code Coverage"
     
     if ($LASTEXITCODE -ne 0 ) { 
         $failedSolutions += $sln

--- a/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Abstractions/MorganStanley.ComposeUI.ProcessExplorer.Abstractions.csproj
+++ b/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Abstractions/MorganStanley.ComposeUI.ProcessExplorer.Abstractions.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Client/MorganStanley.ComposeUI.ProcessExplorer.Client.csproj
+++ b/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Client/MorganStanley.ComposeUI.ProcessExplorer.Client.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Core/MorganStanley.ComposeUI.ProcessExplorer.Core.csproj
+++ b/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Core/MorganStanley.ComposeUI.ProcessExplorer.Core.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Server/MorganStanley.ComposeUI.ProcessExplorer.Server.csproj
+++ b/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Server/MorganStanley.ComposeUI.ProcessExplorer.Server.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/messaging/dotnet/src/Client/MorganStanley.ComposeUI.Messaging.Client.csproj
+++ b/src/messaging/dotnet/src/Client/MorganStanley.ComposeUI.Messaging.Client.csproj
@@ -7,6 +7,10 @@
 		<RootNamespace>MorganStanley.ComposeUI.Messaging</RootNamespace>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<IsPackable>true</IsPackable>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<InternalsVisibleTo Include="$(AssemblyName).Tests" />
 	</ItemGroup>

--- a/src/messaging/dotnet/src/Core/MorganStanley.ComposeUI.Messaging.Core.csproj
+++ b/src/messaging/dotnet/src/Core/MorganStanley.ComposeUI.Messaging.Core.csproj
@@ -9,6 +9,9 @@
 		<RootNamespace>MorganStanley.ComposeUI.Messaging</RootNamespace>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<IsPackable>true</IsPackable>
+	</PropertyGroup>
 	<ItemGroup>
 		<InternalsVisibleTo Include="$(AssemblyName).Tests" />
 	</ItemGroup>
@@ -24,5 +27,4 @@
 	<ItemGroup>
 	  <Folder Include="Exceptions\" />
 	</ItemGroup>
-
 </Project>

--- a/src/messaging/dotnet/src/Host/MorganStanley.ComposeUI.Messaging.Host.csproj
+++ b/src/messaging/dotnet/src/Host/MorganStanley.ComposeUI.Messaging.Host.csproj
@@ -8,6 +8,10 @@
 		<RootNamespace>MorganStanley.ComposeUI.Messaging</RootNamespace>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<IsPackable>true</IsPackable>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="../Core/MorganStanley.ComposeUI.Messaging.Core.csproj" />
 		<ProjectReference Include="../Client/MorganStanley.ComposeUI.Messaging.Client.csproj" />

--- a/src/messaging/dotnet/src/Server/MorganStanley.ComposeUI.Messaging.Server.csproj
+++ b/src/messaging/dotnet/src/Server/MorganStanley.ComposeUI.Messaging.Server.csproj
@@ -7,6 +7,10 @@
 		<RootNamespace>MorganStanley.ComposeUI.Messaging</RootNamespace>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<IsPackable>true</IsPackable>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />

--- a/src/shared/dotnet/src/MorganStanley.ComposeUI.Utilities/MorganStanley.ComposeUI.Utilities.csproj
+++ b/src/shared/dotnet/src/MorganStanley.ComposeUI.Utilities/MorganStanley.ComposeUI.Utilities.csproj
@@ -2,8 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<Nullable>enable</Nullable>
-		<IsPackable>true</IsPackable>
+		<Nullable>enable</Nullable>		
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
In order to publish the nuget packages I decided some streamlining on the dotnet build side is necessary. I separated the changes in 3 commits so they are easier to review and follow in the history.

1. I made the existing CI job to make use of the build scripts in the repository. This change is intended to have the ability to run the same build process locally.
2. I added variable usage for DOTNET_VERSION and NODE_VERSION so we don't have to adjust this across multiple workflow files. This needs to be set up on the main repo as well.
3. I adjusted the packaging scripts and projects so by default projects are not packaged, version is handled in a central location and packages are output in a central location. I enabled packaging for the Messaging libraries where necessary.
4. I added a deploy_to_nuget job to the release.yml workflow that pushes the packages. Note that packages are intentionally listed one by one in order to avoid accidentally pushing undersired packages to nuget.org

Further streamlining of the processes might be desirable, I didn't want to inflate this PR further.