### PR TITLE
chore(github-actions/release): configure lerna to publish public packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,11 +58,6 @@ jobs:
           node-version: 18
           registry-url: https://registry.npmjs.org/
       - run: |
-             dir
-             npm ci
-             npm run build
-             npm whoami
-             npm publish --access public
+             lerna publish from-package --no-private --yes
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        working-directory: ${{ github.workspace }}/src/shell/js/composeui-node-launcher/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,8 @@ jobs:
     name: Upload Release Asset
     needs: build
     runs-on: windows-latest
-
+    permissions:
+      contents: write
     steps:
 
       # Using shared artifact from build workflow


### PR DESCRIPTION
**Changes in this PR**
* Lerna picks up the versions from the package.json and publishes the packages that are not private. For more info: https://lerna.js.org/docs/features/version-and-publish#from-package
* tested on my fork for syntax errors