### PR TITLE
feat(npm-provenance) - Update to Node.js 20 and add npm package provenance

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         dotnet-version: [ '6.0.x' ]
-        node-version: [ '18.x' ]
+        node-version: [ '20.x' ]
     steps:
     - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
     permissions:
       contents: write
     steps:
-
       # Using shared artifact from build workflow
       - name: Download Artifact
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
@@ -52,13 +51,16 @@ jobs:
     name: Publish Package to npmjs
     runs-on: windows-latest
     needs: upload
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 18
+          node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: |
              lerna publish from-package --no-private --yes
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "src/fdc3/js/*",
     "prototypes/process-explorer/*"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MorganStanley/ComposeUI.git"
+  },
   "devDependencies": {
     "lerna": "8.1.2"
   }

--- a/src/fdc3/js/composeui-fdc3/package.json
+++ b/src/fdc3/js/composeui-fdc3/package.json
@@ -23,6 +23,14 @@
     "jest-environment-jsdom": "^29.7.0",
     "rxjs": "^7.8.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/morganstanley/ComposeUI.git"
+  },
+  "publisConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "devDependencies": {
     "@rollup/plugin-commonjs": "25.0.7",
     "@rollup/plugin-node-resolve": "15.2.3",

--- a/src/fdc3/js/composeui-fdc3/package.json
+++ b/src/fdc3/js/composeui-fdc3/package.json
@@ -27,8 +27,8 @@
     "type": "git",
     "url": "git+https://github.com/morganstanley/ComposeUI.git"
   },
-  "publisConfig": {
-    "access": "public",
+  "publishConfig": {
+    "access": "restricted",
     "provenance": true
   },
   "devDependencies": {

--- a/src/messaging/js/composeui-messaging-client/package.json
+++ b/src/messaging/js/composeui-messaging-client/package.json
@@ -16,7 +16,7 @@
         "build:rollup": "rollup -c",
         "test": "jest"
     },
-    "publisConfig": {
+    "publishConfig": {
         "access": "public",
         "provenance": true
     },

--- a/src/messaging/js/composeui-messaging-client/package.json
+++ b/src/messaging/js/composeui-messaging-client/package.json
@@ -16,6 +16,14 @@
         "build:rollup": "rollup -c",
         "test": "jest"
     },
+    "publisConfig": {
+        "access": "public",
+        "provenance": true
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/morganstanley/ComposeUI.git"
+    },
     "author": "Morgan Stanley",
     "license": "Apache-2.0",
     "devDependencies": {

--- a/src/shell/js/composeui-node-launcher/package.json
+++ b/src/shell/js/composeui-node-launcher/package.json
@@ -10,13 +10,17 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/morganstanley/ComposeUI.git#main"
+    "url": "git+https://github.com/morganstanley/ComposeUI.git"
   },
   "scripts": {
     "clean": "rimraf output",
     "build": "npm run clean && tsc",
     "install": "node ./src/cli/install.js",
     "test": "jest"
+  },
+  "publisConfig": {
+    "access": "public",
+    "provenance": true
   },
   "bin": {
     "composeui": "./output/cli/cli.js"

--- a/src/shell/js/composeui-node-launcher/package.json
+++ b/src/shell/js/composeui-node-launcher/package.json
@@ -18,7 +18,7 @@
     "install": "node ./src/cli/install.js",
     "test": "jest"
   },
-  "publisConfig": {
+  "publishConfig": {
     "access": "public",
     "provenance": true
   },


### PR DESCRIPTION
Add npm package provenance, modified package.json files to contain repository and publish information.
Based on the documentation: https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools using 3rd party libraries (Lerna) to publish we should define EITHER an environment variable (NPM_CONFIG_PROVENANCE) OR add publish configs to the package.json files OR add a .npmrc file where we can set the provenance to true.

Based on the release https://github.com/lerna/lerna/releases/tag/6.6.2 : Lerna does support provenance from the 6.6.2 version. We are on the 8.1.2.

FYI: https://github.com/lerna/lerna/issues/3657 ;

I added package.json reporitory and publishConfigs and environment variable as well to be sure that the provenance flag is set.
