### PR TITLE
chore: 0.1.0-alpha.4 - Add common nuget metadata

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,13 @@
     <PropertyGroup>
         <IsPackable>false</IsPackable>
         <VersionPrefix>0.1.0</VersionPrefix>
-        <VersionSuffix>alpha.3</VersionSuffix>
+        <VersionSuffix>alpha.4</VersionSuffix>
+    </PropertyGroup>
+	
+    <PropertyGroup>
+        <Company>Morgan Stanley</Company>
+        <Authors>Morgan Stanley</Authors>
+        <RepositoryUrl>https://github.com/morganstanley/ComposeUI</RepositoryUrl>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
Adding metadata for including version and license