### PR TITLE
Use Repository Variables for Node.js and dotnet version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,12 +23,13 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        dotnet-version: [ '6.0.x' ]
-        node-version: [ '20.x' ]
+        dotnet-version: [ '${{ vars.DOTNET_VERSION }}' ]
+        node-version: [ '${{ vars.NODE_VERSION }}' ]
     steps:
     - name: Checkout
       uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-
+    
+    - run: echo Calling setup-node with node-version ${{ vars.NODE_VERSION }}
     - name: Setup Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:
@@ -44,6 +45,7 @@ jobs:
     - name: Test JavaScript
       run: npx lerna run test
 
+    - run: echo Calling setup-dotnet with dotnet-version ${{ vars.DOTNET_VERSION }}
     - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
       uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
       with:


### PR DESCRIPTION
This is a test if Node.js 20 and .NET 6 is picked up from the repository variable on a feature branch.