### PR TITLE
0.1.0-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20488,7 +20488,7 @@
     },
     "src/messaging/js/composeui-messaging-client": {
       "name": "@morgan-stanley/composeui-messaging-client",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-alpha.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^18.11.18",
@@ -20513,7 +20513,7 @@
     },
     "src/shell/js/composeui-node-launcher": {
       "name": "@morgan-stanley/composeui-node-launcher",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-alpha.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/messaging/js/composeui-messaging-client/README.md
+++ b/src/messaging/js/composeui-messaging-client/README.md
@@ -1,4 +1,4 @@
-# Messaging-JS
+# @morgan-stanley/composeui-messaging-client
 This package contains the client used to connect to the MessageRouter from web modules in ComposeUI.
 
 ## Setup

--- a/src/messaging/js/composeui-messaging-client/package.json
+++ b/src/messaging/js/composeui-messaging-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@morgan-stanley/composeui-messaging-client",
-    "version": "0.1.0-alpha.3",
+    "version": "0.1.0-alpha.4",
     "private": false,
     "description": "JavaScript client for ComposeUI's Message Router",
     "type": "module",

--- a/src/shell/js/composeui-node-launcher/package.json
+++ b/src/shell/js/composeui-node-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morgan-stanley/composeui-node-launcher",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "private": false,
   "description": "Package to launch ComposeUI from Node.js",
   "main": "output/index.js",


### PR DESCRIPTION
* Bumping Release Ready NPM packages' version to 0.1.0-alpha.4
* Changing JS Messaging Client README title to have the package name.