### PR TITLE
chore(NOTICE): Remove License notice for super-rpc-dotnet-poc

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,12 +2,3 @@ Morgan Stanley ComposeUI
 Copyright 2021 Morgan Stanley
 
 This product includes software developed at Morgan Stanley (http://www.morganstanley.com).
-
--------------------------------
-
-ComposeUI uses third-party libraries or other resources that may be distributed under licenses different than the ComposeUI software.
-
-License notice for super-rpc-dotnet-poc
-https://github.com/kruplm/super-rpc-dotnet-poc/blob/main/LICENSE
-Copyright (c) 2022 Szilveszter Safar
-The MIT License (MIT)


### PR DESCRIPTION
Removing License notice for super-rpc-dotnet-poc as we've replaced it's usages with gRPC earlier