### PR TITLE
fix(module-loader) - Fixed ModuleLoader behavior with multiple modulecatalogs

### DIFF
--- a/architecture/adr-014-module-catalog.md
+++ b/architecture/adr-014-module-catalog.md
@@ -1,0 +1,28 @@
+<!-- Morgan Stanley makes this available to you under the Apache License, Version 2.0 (the "License"). You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0. See the NOTICE file distributed with this work for additional information regarding copyright ownership. Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. -->
+
+| Type          | ID            | Status        | Title                   |
+| ------------- | ------------- | ------------- | ----------------------- |
+| ADR           | adr-014       | Accepted      | Multiple ModuleCatalogs |
+
+
+# Architecture Decision Record: Multiple ModuleCatalogs
+
+## Context
+ComposeUI aims to support many different kind of modules. These modules, that can be started by the ModuleLoader should be stored in ModuleCatalogs and every module should have its unique module id. The user should have the ability to handle multiple ModuleCatalogs with the ModuleLoader.
+
+General problem statement:
+- When multiple ModuleCatalogs are used, some modules could have the same module id in different ModuleCatalogs which could cause issues while starting or stopping the module via the ModuleLoader.
+
+## Decision
+- If the same module id is being used for multiple modules (likely in different ModuleCatalogs), the first occurrence will be used. In case of multiple ModuleCatalog registrations, the order of the registration determines which module can be used.
+
+# Alternative solutions that we considered
+- Throwing an exception when multiple modules have the same moduleId either in one or multiple ModuleCatalogs. This might cause an issue that is unresolvable by the developer or the enduser.
+- Prefixing the modules with the name of the ModuleCatalog, but prefixing ids would be non-standard.
+- Aggregating the registered ModuleCatalogs should be implemented by the developer of the application.
+ 
+## Consequences
+- Our implementation is more permissive than the standard. 
+- We must ensure keeping the order of the ModuleCatalog registrations as the order of registrations will determine which module is contained by our aggregated ModuleCatalog in case of duplicate moduleIds.
+- We must ensure keeping the order of the modules within the invidual ModuleCatalogs as the order of the registered modules will determine which module is contained by our aggregated ModuleCatalog in case of duplicate moduleIds.
+- We must ensure this order when fetching modules asynchronously from the ModuleCatalogs.

--- a/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader.Abstractions/IModuleCatalog.cs
+++ b/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader.Abstractions/IModuleCatalog.cs
@@ -15,6 +15,7 @@ namespace MorganStanley.ComposeUI.ModuleLoader;
 /// <summary>
 /// Represents a collection of modules that can be started in the scope of the application.
 /// </summary>
+/// <exception cref="ModuleNotFoundException">The requested module was not found in the catalog</exception>
 public interface IModuleCatalog
 {
     /// <summary>

--- a/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader.Abstractions/ModuleLoaderException.cs
+++ b/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader.Abstractions/ModuleLoaderException.cs
@@ -1,0 +1,36 @@
+﻿/*
+* Morgan Stanley makes this available to you under the Apache License,
+* Version 2.0 (the "License"). You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0.
+*
+* See the NOTICE file distributed with this work for additional information
+* regarding copyright ownership. Unless required by applicable law or agreed
+* to in writing, software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+* or implied. See the License for the specific language governing permissions
+* and limitations under the License.
+*/
+
+using System.Runtime.Serialization;
+
+namespace MorganStanley.ComposeUI.ModuleLoader;
+
+public class ModuleLoaderException : Exception
+{
+    public ModuleLoaderException()
+    {
+    }
+
+    protected ModuleLoaderException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+    }
+
+    public ModuleLoaderException(string? message) : base(message)
+    {
+    }
+
+    public ModuleLoaderException(string? message, Exception? innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader.Abstractions/ModuleNotFoundException.cs
+++ b/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader.Abstractions/ModuleNotFoundException.cs
@@ -1,0 +1,22 @@
+﻿/*
+* Morgan Stanley makes this available to you under the Apache License,
+* Version 2.0 (the "License"). You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0.
+*
+* See the NOTICE file distributed with this work for additional information
+* regarding copyright ownership. Unless required by applicable law or agreed
+* to in writing, software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+* or implied. See the License for the specific language governing permissions
+* and limitations under the License.
+*/
+
+namespace MorganStanley.ComposeUI.ModuleLoader;
+
+public class ModuleNotFoundException : ModuleLoaderException
+{
+    public ModuleNotFoundException(string moduleId) : base($"Unknown module id: {moduleId}")
+    {
+    }
+}

--- a/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader/AggregateModuleCatalog.cs
+++ b/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader/AggregateModuleCatalog.cs
@@ -1,0 +1,83 @@
+﻿// Morgan Stanley makes this available to you under the Apache License,
+// Version 2.0 (the "License"). You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0.
+// 
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership. Unless required by applicable law or agreed
+// to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions
+// and limitations under the License.
+
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MorganStanley.ComposeUI.ModuleLoader;
+
+internal class AggregateModuleCatalog : IModuleCatalog
+{
+    private readonly IEnumerable<IModuleCatalog> _moduleCatalogs;
+    private readonly ILogger _logger;
+
+    public AggregateModuleCatalog(
+        IEnumerable<IModuleCatalog> moduleCatalogs,
+        ILogger? logger = null)
+    {
+        _moduleCatalogs = moduleCatalogs;
+        _logger = logger ?? NullLogger.Instance;
+        _lazyEnumerateModules = new Lazy<Task>(EnumerateModulesCore);
+    }
+
+    public async Task<IModuleManifest> GetManifest(string moduleId)
+    {
+        await EnumerateModules();
+
+        return _moduleIdToCatalog.TryGetValue(moduleId, out var catalog)
+            ? await catalog.GetManifest(moduleId)
+            : throw new ModuleNotFoundException(moduleId);
+    }
+
+    public async Task<IEnumerable<string>> GetModuleIds()
+    {
+        await EnumerateModules();
+
+        return _moduleIdToCatalog.Keys;
+    }
+
+    private readonly Lazy<Task> _lazyEnumerateModules;
+    private readonly ConcurrentDictionary<string, IModuleCatalog> _moduleIdToCatalog = new();
+
+    private Task EnumerateModules() => _lazyEnumerateModules.Value;
+
+    private async Task EnumerateModulesCore()
+    {
+        var moduleCatalogs = _moduleCatalogs.ToDictionary(x => x, y => y.GetModuleIds());
+        // Services/DI registrations appear in the order they were registered when resolved via IEnumerable<{SERVICE}>
+        // https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection
+        foreach (var moduleCatalog in moduleCatalogs)
+        {
+            var moduleIds = await moduleCatalog.Value;
+
+            foreach (var moduleId in moduleIds)
+            {
+                if (!_moduleIdToCatalog.TryGetValue(moduleId, out var catalog))
+                {
+                    _moduleIdToCatalog[moduleId] = moduleCatalog.Key;
+                }
+                else
+                {
+                    if (_logger.IsEnabled(LogLevel.Warning))
+                    {
+                        var moduleManifest = await catalog.GetManifest(moduleId);
+                        _logger.LogWarning(
+                            $"ModuleId: {moduleId} is already contained by an another {nameof(IModuleCatalog)} with name {moduleManifest.Name}. Please consider using unique ids for modules. The first occurrence of the module will be saved and used by the {nameof(ModuleLoader)}.");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader/MorganStanley.ComposeUI.ModuleLoader.csproj
+++ b/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader/MorganStanley.ComposeUI.ModuleLoader.csproj
@@ -18,6 +18,7 @@ See the License for the specific language governing permissions and limitations 
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="System.Reactive" />
   </ItemGroup>
 

--- a/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader/Runners/NativeModuleRunner.cs
+++ b/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader/Runners/NativeModuleRunner.cs
@@ -22,7 +22,7 @@ internal class NativeModuleRunner : IModuleRunner
     {
         if (!startupContext.ModuleInstance.Manifest.TryGetDetails(out NativeManifestDetails details))
         {
-            throw new Exception("Unable to get native maifest details");
+            throw new Exception("Unable to get native manifest details");
         }
 
         startupContext.AddProperty(new EnvironmentVariables(details.EnvironmentVariables));

--- a/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Abstractions.Tests/MorganStanley.ComposeUI.ModuleLoader.Abstractions.Tests.csproj
+++ b/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Abstractions.Tests/MorganStanley.ComposeUI.ModuleLoader.Abstractions.Tests.csproj
@@ -10,6 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="FluentAssertions" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="Moq" />
 		<PackageReference Include="xunit" />

--- a/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Abstractions.Tests/StartupContextTests.cs
+++ b/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Abstractions.Tests/StartupContextTests.cs
@@ -10,6 +10,7 @@
 // or implied. See the License for the specific language governing permissions
 // and limitations under the License.
 
+using FluentAssertions;
 using Moq;
 
 namespace MorganStanley.ComposeUI.ModuleLoader.Abstractions.Tests;
@@ -25,20 +26,21 @@ public class StartupContextTests
             new MyContextInfo { Name = "Test2" }
         };
 
-        StartupContext context = new StartupContext(new StartRequest("test"), Mock.Of<IModuleInstance>());
+        var context = new StartupContext(new StartRequest("test"), Mock.Of<IModuleInstance>());
         context.AddProperty(expected[0]);
         context.AddProperty(expected[1]);
 
         var result = context.GetProperties();
-        Assert.NotNull(result);
-        Assert.Equal(expected, result);
+        result.Should().NotBeNull();
+        result.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
     public void GivenNullArgument_WhenAdd_ThrowsArgumentNullException()
     {
-        StartupContext context = new StartupContext(new StartRequest("test"), Mock.Of<IModuleInstance>());
-        Assert.Throws<ArgumentNullException>(() => context.AddProperty<object>(null!));
+        var context = new StartupContext(new StartRequest("test"), Mock.Of<IModuleInstance>());
+        var action = () => context.AddProperty<object>(null!);
+        action.Should().Throw<ArgumentNullException>();
     }
 
     private class MyContextInfo

--- a/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/AggregateModuleCatalogTests.cs
+++ b/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/AggregateModuleCatalogTests.cs
@@ -1,0 +1,147 @@
+﻿// Morgan Stanley makes this available to you under the Apache License,
+// Version 2.0 (the "License"). You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0.
+// 
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership. Unless required by applicable law or agreed
+// to in writing, software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions
+// and limitations under the License.
+
+using FluentAssertions;
+
+namespace MorganStanley.ComposeUI.ModuleLoader.Tests;
+
+public class AggregateModuleCatalogTests
+{
+    private readonly IModuleCatalog _moduleCatalog = new AggregateModuleCatalog(
+        new[]
+        {
+            new MockModuleCatalog(new[]
+            {
+                new MockModuleManifest("testModuleId", "testModuleName"),
+                new MockModuleManifest("testModuleId1", "testModuleName1"),
+                new MockModuleManifest("testModuleId2", "testModuleName2"),
+                new MockModuleManifest("testModuleId3", "testModuleName3"),
+                new MockModuleManifest("testModuleId4", "testModuleName4")
+            }),
+            new MockModuleCatalog(new[]
+            {
+                new MockModuleManifest("testModuleId5", "testModuleName5"),
+                new MockModuleManifest("testModuleId", "testModuleName8"),
+                new MockModuleManifest("testModuleId6", "testModuleName6"),
+            }),
+            new MockModuleCatalog(new[]
+            {
+                new MockModuleManifest("testModuleId", "testModuleName9"),
+            }),
+            new MockModuleCatalog(new[]
+            {
+                new MockModuleManifest("testModuleId7", "testModuleName7"),
+            }),
+            new MockModuleCatalog(Enumerable.Empty<MockModuleManifest>()),
+        });
+
+    [Theory]
+    [ClassData(typeof(AggregateModuleCatalogReturnManifestTheoryData))]
+    public async Task GetManifest_ReturnsModuleManifest_WhenModuleIdPassed(string moduleId, IModuleManifest expectedModuleManifest)
+    {
+        var result = await _moduleCatalog.GetManifest(moduleId);
+        result.Should().NotBeNull();
+        result.Should().BeEquivalentTo(expectedModuleManifest);
+    }
+
+    [Theory]
+    [InlineData("noModuleId")]
+    [InlineData("testModuleId8")]
+    public async Task GetManifest_ThrowsModuleNotFoundException_WhenNoModuleIdFound(string moduleId)
+    {
+        var action = () => _moduleCatalog.GetManifest(moduleId);
+        await action.Should().ThrowAsync<ModuleNotFoundException>();
+    }
+
+    [Theory]
+    [InlineData("testModuleId")]
+    public async Task GetManifest_ReturnsTheFirstOccurrence_WhenMultipleCatalogContainsTheSameModuleId(string moduleId)
+    {
+        var result = await _moduleCatalog.GetManifest(moduleId);
+        result.Should().NotBeNull();
+        result.Should().BeEquivalentTo(new MockModuleManifest("testModuleId", "testModuleName"));
+    }
+
+    [Fact]
+    public async Task GetModuleIds_ReturnsTheUniqueModules()
+    {
+        var result = await _moduleCatalog.GetModuleIds();
+        result.Should().NotBeNull();
+        result.Should().HaveCount(8);
+        result.Should().BeEquivalentTo(
+            new[]
+            {
+                "testModuleId",
+                "testModuleId1",
+                "testModuleId2",
+                "testModuleId3",
+                "testModuleId4",
+                "testModuleId5",
+                "testModuleId6",
+                "testModuleId7",
+            });
+    }
+
+    private class MockModuleCatalog : IModuleCatalog
+    {
+        private readonly IEnumerable<IModuleManifest> _modules;
+
+        public MockModuleCatalog(IEnumerable<IModuleManifest> modules)
+        {
+            _modules = modules;
+        }
+
+        public Task<IModuleManifest> GetManifest(string moduleId)
+        {
+            var module = _modules.FirstOrDefault(module => module.Id == moduleId);
+            if (module == null)
+            {
+                throw new NullReferenceException(moduleId);
+            }
+
+            return Task.FromResult(module);
+        }
+
+        public Task<IEnumerable<string>> GetModuleIds()
+        {
+            return Task.FromResult(_modules.Select(module => module.Id));
+        }
+    }
+
+    private class MockModuleManifest : IModuleManifest
+    {
+        private string _id;
+        private string _name;
+
+        public MockModuleManifest(string id, string name)
+        {
+            _id = id;
+            _name = name;
+        }
+
+        public string Id => _id;
+
+        public string Name => _name;
+
+        public string ModuleType => "dummy";
+    }
+
+    private class AggregateModuleCatalogReturnManifestTheoryData : TheoryData
+    {
+        public AggregateModuleCatalogReturnManifestTheoryData()
+        {
+            AddRow("testModuleId1", new MockModuleManifest("testModuleId1", "testModuleName1"));
+            AddRow("testModuleId2", new MockModuleManifest("testModuleId2", "testModuleName2"));
+            AddRow("testModuleId5", new MockModuleManifest("testModuleId5", "testModuleName5"));
+        }
+    }
+}

--- a/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -10,6 +10,7 @@
 // or implied. See the License for the specific language governing permissions
 // and limitations under the License.
 
+using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using MorganStanley.ComposeUI.ModuleLoader.Runners;
 
@@ -23,8 +24,8 @@ public class ServiceCollectionExtensionsTests
         var services = new ServiceCollection()
             .AddModuleLoader();
 
-        Assert.Equal(1, services.Count(s => s.ServiceType == typeof(IModuleLoader) && s.ImplementationType == typeof(ModuleLoader)));
-        Assert.Equal(1, services.Count(s => s.ServiceType == typeof(IModuleRunner) && s.ImplementationType == typeof(WebModuleRunner)));
-        Assert.Equal(1, services.Count(s => s.ServiceType == typeof(IModuleRunner) && s.ImplementationType == typeof(NativeModuleRunner)));
+        services.Count(s => s.ServiceType == typeof(IModuleLoader) && s.ImplementationType == typeof(ModuleLoader)).Should().Be(1);
+        services.Count(s => s.ServiceType == typeof(IModuleRunner) && s.ImplementationType == typeof(WebModuleRunner)).Should().Be(1);
+        services.Count(s => s.ServiceType == typeof(IModuleRunner) && s.ImplementationType == typeof(NativeModuleRunner)).Should().Be(1);
     }
 }

--- a/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/ModuleInstanceTests.cs
+++ b/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/ModuleInstanceTests.cs
@@ -11,6 +11,7 @@
 // and limitations under the License.
 
 
+using FluentAssertions;
 using Moq;
 
 namespace MorganStanley.ComposeUI.ModuleLoader.Tests;
@@ -22,17 +23,19 @@ public class ModuleInstanceTests
     [Fact]
     public void GivenNullArguments_WhenCtor_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() => new ModuleInstance(_testGuid, null!, new StartRequest("test")));
-        Assert.Throws<ArgumentNullException>(() => new ModuleInstance(_testGuid, new Mock<IModuleManifest>().Object, null!));
+        var action1 = () => new ModuleInstance(_testGuid, null!, new StartRequest("test"));
+        action1.Should().Throw<ArgumentNullException>();
+
+        var action2 = () => new ModuleInstance(_testGuid, new Mock<IModuleManifest>().Object, null!);
+        action2.Should().Throw<ArgumentNullException>();
     }
 
     [Fact]
     public void WhenNewModuleInstance_GetProperties_ReturnsEmptyCollection()
     {
         var moduleInstance = new ModuleInstance(_testGuid, new Mock<IModuleManifest>().Object, new StartRequest("test"));
-
         var properties = moduleInstance.GetProperties();
-        Assert.Empty(properties);
+        properties.Should().BeEmpty();
     }
 
     [Fact]
@@ -44,6 +47,6 @@ public class ModuleInstanceTests
         moduleInstance.AddProperties(testProperties);
         var properties = moduleInstance.GetProperties();
 
-        Assert.Equal(testProperties, properties);
+        testProperties.Should().BeEquivalentTo(properties);
     }
 }

--- a/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/ModuleLoaderTests.cs
+++ b/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/ModuleLoaderTests.cs
@@ -10,6 +10,7 @@
 // or implied. See the License for the specific language governing permissions
 // and limitations under the License.
 
+using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 
@@ -20,23 +21,28 @@ namespace MorganStanley.ComposeUI.ModuleLoader.Tests
         [Fact]
         public void GivenNullArguments_WhenCtor_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new ModuleLoader(null!, Enumerable.Empty<IModuleRunner>(), Enumerable.Empty<IStartupAction>()));
-            Assert.Throws<ArgumentNullException>(() => new ModuleLoader(new Mock<IEnumerable<IModuleCatalog>>().Object, null!, Enumerable.Empty<IStartupAction>()));
-            Assert.Throws<ArgumentNullException>(() => new ModuleLoader(new Mock<IEnumerable<IModuleCatalog>>().Object, Enumerable.Empty<IModuleRunner>(), null!));
+            var action1 = () => new ModuleLoader(null!, Enumerable.Empty<IModuleRunner>(), Enumerable.Empty<IStartupAction>());
+            var action2 = () => new ModuleLoader(new Mock<IEnumerable<IModuleCatalog>>().Object, null!, Enumerable.Empty<IStartupAction>());
+            var action3 = () => new ModuleLoader(new Mock<IEnumerable<IModuleCatalog>>().Object, Enumerable.Empty<IModuleRunner>(), null!);
+
+            action1.Should().Throw<ArgumentNullException>();
+            action2.Should().Throw<ArgumentNullException>();
+            action3.Should().Throw<ArgumentNullException>();
         }
 
         [Fact]
-        public void GivenUnknownModuleId_WhenStart_ThrowsException()
+        public async void GivenUnknownModuleId_WhenStart_ThrowsException()
         {
             var moduleCatalogMock = new Mock<IModuleCatalog>();
             moduleCatalogMock.Setup(c => c.GetManifest(It.IsAny<string>())).Returns(Task.FromResult<IModuleManifest?>(null));
 
             var moduleLoader = new ModuleLoader(new[] { moduleCatalogMock.Object }, Enumerable.Empty<IModuleRunner>(), Enumerable.Empty<IStartupAction>());
-            Assert.ThrowsAsync<Exception>(async () => await moduleLoader.StartModule(new StartRequest("invalid")));
+            var action = () => moduleLoader.StartModule(new StartRequest("invalid"));
+            await action.Should().ThrowAsync<Exception>();
         }
 
         [Fact]
-        public void WhenNoModuleRunnerAvailable_WhenStart_ThrowsException()
+        public async Task WhenNoModuleRunnerAvailable_WhenStart_ThrowsException()
         {
             var moduleManifestMock = new Mock<IModuleManifest>();
             moduleManifestMock.Setup(m => m.ModuleType).Returns("test");
@@ -46,7 +52,8 @@ namespace MorganStanley.ComposeUI.ModuleLoader.Tests
             testModuleRunnerMock.Setup(r => r.ModuleType).Returns("other");
 
             var moduleLoader = new ModuleLoader(new[] { moduleCatalogMock.Object }, new[] { testModuleRunnerMock.Object }, Enumerable.Empty<IStartupAction>());
-            Assert.ThrowsAsync<Exception>(async () => await moduleLoader.StartModule(new StartRequest("valid")));
+            var action = () => moduleLoader.StartModule(new StartRequest("valid"));
+            await action.Should().ThrowAsync<Exception>();
         }
 
         [Fact]
@@ -77,13 +84,13 @@ namespace MorganStanley.ComposeUI.ModuleLoader.Tests
 
             var serviceProvider = new ServiceCollection()
                 .AddModuleLoader()
-                .AddSingleton<IModuleCatalog>(moduleCatalogMock.Object)
+                .AddSingleton<IEnumerable<IModuleCatalog>>(new[] { moduleCatalogMock.Object })
                 .AddSingleton<IStartupAction>(startupActionMock.Object)
                 .BuildServiceProvider();
 
             var moduleLoader = serviceProvider.GetRequiredService<IModuleLoader>();
-            bool startingEventReceived = false;
-            bool startedEventReceived = false;
+            var startingEventReceived = false;
+            var startedEventReceived = false;
             moduleLoader.LifetimeEvents.Subscribe(x =>
             {
                 if (x.EventType == LifetimeEventType.Starting)
@@ -95,20 +102,19 @@ namespace MorganStanley.ComposeUI.ModuleLoader.Tests
 
             var startRequest = new StartRequest(moduleId);
             var moduleInstance = await moduleLoader.StartModule(startRequest);
-            Assert.NotNull(moduleInstance);
-            Assert.Equal(moduleManifestMock.Object, moduleInstance.Manifest);
-            Assert.Equal(startRequest, moduleInstance.StartRequest);
+            moduleInstance.Should().NotBeNull();
+            moduleManifestMock.Object.Should().BeEquivalentTo(moduleInstance.Manifest);
+            startRequest.Should().BeEquivalentTo(moduleInstance.StartRequest);
+            
             var allProperties = moduleInstance.GetProperties();
-
             var webProperties = allProperties.OfType<WebStartupProperties>().Single();
-            Assert.Equal(webManifestDetails.IconUrl, webProperties.IconUrl);
-            Assert.Equal(webManifestDetails.Url, webProperties.Url);
+            webManifestDetails.IconUrl.Should().BeEquivalentTo(webProperties.IconUrl);
+            webManifestDetails.Url.Should().BeEquivalentTo(webProperties.Url);
 
             var stringProperty = allProperties.OfType<string>().Single();
-            Assert.Equal(testProperty, stringProperty);
-
-            Assert.True(startingEventReceived);
-            Assert.True(startedEventReceived);
+            testProperty.Should().BeEquivalentTo(stringProperty);
+            startingEventReceived.Should().BeTrue();
+            startedEventReceived.Should().BeTrue();
         }
-    }
+    } 
 }

--- a/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/ModuleLoaderTests.cs
+++ b/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/ModuleLoaderTests.cs
@@ -21,8 +21,8 @@ namespace MorganStanley.ComposeUI.ModuleLoader.Tests
         public void GivenNullArguments_WhenCtor_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => new ModuleLoader(null!, Enumerable.Empty<IModuleRunner>(), Enumerable.Empty<IStartupAction>()));
-            Assert.Throws<ArgumentNullException>(() => new ModuleLoader(new Mock<IModuleCatalog>().Object, null!, Enumerable.Empty<IStartupAction>()));
-            Assert.Throws<ArgumentNullException>(() => new ModuleLoader(new Mock<IModuleCatalog>().Object, Enumerable.Empty<IModuleRunner>(), null!));
+            Assert.Throws<ArgumentNullException>(() => new ModuleLoader(new Mock<IEnumerable<IModuleCatalog>>().Object, null!, Enumerable.Empty<IStartupAction>()));
+            Assert.Throws<ArgumentNullException>(() => new ModuleLoader(new Mock<IEnumerable<IModuleCatalog>>().Object, Enumerable.Empty<IModuleRunner>(), null!));
         }
 
         [Fact]
@@ -31,7 +31,7 @@ namespace MorganStanley.ComposeUI.ModuleLoader.Tests
             var moduleCatalogMock = new Mock<IModuleCatalog>();
             moduleCatalogMock.Setup(c => c.GetManifest(It.IsAny<string>())).Returns(Task.FromResult<IModuleManifest?>(null));
 
-            var moduleLoader = new ModuleLoader(moduleCatalogMock.Object, Enumerable.Empty<IModuleRunner>(), Enumerable.Empty<IStartupAction>());
+            var moduleLoader = new ModuleLoader(new[] { moduleCatalogMock.Object }, Enumerable.Empty<IModuleRunner>(), Enumerable.Empty<IStartupAction>());
             Assert.ThrowsAsync<Exception>(async () => await moduleLoader.StartModule(new StartRequest("invalid")));
         }
 
@@ -45,7 +45,7 @@ namespace MorganStanley.ComposeUI.ModuleLoader.Tests
             var testModuleRunnerMock = new Mock<IModuleRunner>();
             testModuleRunnerMock.Setup(r => r.ModuleType).Returns("other");
 
-            var moduleLoader = new ModuleLoader(moduleCatalogMock.Object, new[] { testModuleRunnerMock.Object }, Enumerable.Empty<IStartupAction>());
+            var moduleLoader = new ModuleLoader(new[] { moduleCatalogMock.Object }, new[] { testModuleRunnerMock.Object }, Enumerable.Empty<IStartupAction>());
             Assert.ThrowsAsync<Exception>(async () => await moduleLoader.StartModule(new StartRequest("valid")));
         }
 
@@ -67,6 +67,7 @@ namespace MorganStanley.ComposeUI.ModuleLoader.Tests
             moduleManifestMock.Setup(m => m.ModuleType).Returns(ModuleType.Web);
             moduleManifestMock.Setup(m => m.Details).Returns(webManifestDetails);
             moduleCatalogMock.Setup(c => c.GetManifest(moduleId)).Returns(Task.FromResult<IModuleManifest>(moduleManifestMock.Object));
+            moduleCatalogMock.Setup(catalog => catalog.GetModuleIds()).Returns(Task.FromResult<IEnumerable<string>>(new[] { moduleId }));
             startupActionMock.Setup(s => s.InvokeAsync(It.IsAny<StartupContext>(), It.IsAny<Func<Task>>()))
                 .Callback<StartupContext, Func<Task>>((startupContext, next) =>
                 {

--- a/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/MorganStanley.ComposeUI.ModuleLoader.Tests.csproj
+++ b/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/MorganStanley.ComposeUI.ModuleLoader.Tests.csproj
@@ -11,6 +11,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="FluentAssertions" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 		<PackageReference Include="Moq" />

--- a/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/Runners/NativeModuleRunnerTests.cs
+++ b/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/Runners/NativeModuleRunnerTests.cs
@@ -11,6 +11,8 @@
 // and limitations under the License.
 
 using System.Diagnostics;
+using FluentAssertions;
+using FluentAssertions.Execution;
 using Moq;
 using MorganStanley.ComposeUI.ModuleLoader.Runners;
 using MorganStanley.ComposeUI.ModuleLoader.Tests.TestUtils;
@@ -26,7 +28,7 @@ public class NativeModuleRunnerTests : IDisposable
     [Fact]
     public void ModuleType_is_Native()
     {
-        Assert.Equal(ModuleType.Native, _runner.ModuleType);
+        _runner.ModuleType.Should().Be(ModuleType.Native);
     }
 
     [Fact]
@@ -53,13 +55,13 @@ public class NativeModuleRunnerTests : IDisposable
 
         var processInfo = startupContext.GetOrAddProperty<MainProcessInfo>(() =>
         {
-            Assert.Fail("No MainProcessInfo found");
+            Execute.Assertion.FailWith("No MainProcessInfo found");
             return null;
         });
 
         _mainProcess = processInfo.MainProcess;
         var result = await _mainProcess.WaitForExitAsync(Timeout);
-        Assert.Equal($"Hello ComposeUI! I am {randomString}", result.Output.Trim());
+        result.Output.Trim().Should().Be($"Hello ComposeUI! I am {randomString}");
     }
 
     [Fact]
@@ -86,13 +88,13 @@ public class NativeModuleRunnerTests : IDisposable
 
         var processInfo = startupContext.GetOrAddProperty<MainProcessInfo>(() =>
         {
-            Assert.Fail("No MainProcessInfo found");
+            Execute.Assertion.FailWith("No MainProcessInfo found");
             return null;
         });
 
         _mainProcess = processInfo.MainProcess;
         var result = await _mainProcess.WaitForExitAsync(Timeout);
-        Assert.Contains($"{variableName}={randomString}", result.Output);
+        result.Output.Should().Contain($"{variableName}={randomString}");
     }
 
     [Fact]
@@ -119,13 +121,13 @@ public class NativeModuleRunnerTests : IDisposable
 
         var processInfo = startupContext.GetOrAddProperty<MainProcessInfo>(() =>
         {
-            Assert.Fail("No MainProcessInfo found");
+            Execute.Assertion.FailWith("No MainProcessInfo found");
             return null;
         });
 
         _mainProcess = processInfo.MainProcess;
         var result = await _mainProcess.WaitForExitAsync(Timeout);
-        Assert.Contains($"{variableName}={randomString}", result.Output);
+        result.Output.Should().Contain($"{variableName}={randomString}");
     }
 
     [Fact]
@@ -156,13 +158,13 @@ public class NativeModuleRunnerTests : IDisposable
 
         var processInfo = startupContext.GetOrAddProperty<MainProcessInfo>(() =>
         {
-            Assert.Fail("No MainProcessInfo found");
+            Execute.Assertion.FailWith("No MainProcessInfo found");
             return null;
         });
 
         _mainProcess = processInfo.MainProcess;
         var result = await _mainProcess.WaitForExitAsync(Timeout);
-        Assert.Contains($"{variableName}={randomString}", result.Output);
+        result.Output.Should().Contain($"{variableName}={randomString}");
     }
 
     private Task RedirectMainProcessOutput(StartupContext startupContext)

--- a/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/Runners/WebModuleRunnerTests.cs
+++ b/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/Runners/WebModuleRunnerTests.cs
@@ -11,6 +11,7 @@
 // and limitations under the License.
 
 
+using FluentAssertions;
 using Moq;
 using MorganStanley.ComposeUI.ModuleLoader.Runners;
 
@@ -22,7 +23,7 @@ public class WebModuleRunnerTests
     public void ModuleType_Is_Web()
     {
         var runner = new WebModuleRunner();
-        Assert.Equal(ModuleType.Web, runner.ModuleType);
+        runner.ModuleType.Should().Be(ModuleType.Web);
     }
 
     [Fact]
@@ -40,10 +41,10 @@ public class WebModuleRunnerTests
         await runner.Start(startupContext, MockPipeline);
 
         var result = startupContext.GetProperties();
-        Assert.NotNull(result);
+        result.Should().NotBeNull();
         var webProperties = result.OfType<WebStartupProperties>().Single();
-        Assert.Equal(details.IconUrl, webProperties.IconUrl);
-        Assert.Equal(details.Url, webProperties.Url);
+        details.IconUrl.Should().BeEquivalentTo(webProperties.IconUrl);
+        details.Url.Should().BeEquivalentTo(webProperties.Url);
     }
 
     private class MockModuleManifest : IModuleManifest<WebManifestDetails>


### PR DESCRIPTION
Changes:
- picked up changes from branch and commits related to the ModuleLoader when it tries to register its ModuleCatalog https://github.com/morganstanley/ComposeUI/commit/89ec2d9e1f9be47df0cacfdbb4586d9405d0b332 && https://github.com/morganstanley/ComposeUI/commit/57ad7daab2f8e28d63b335562b7f8b2bdf20fe79
- fixed tests when it registers its modulecatalogs (mocking array of catalogs)


Please refer to the PR https://github.com/morganstanley/ComposeUI/pull/569 that I accidentally closed.
I copied all the review comments/suggestions that the PR received and resolved them if they were marked as Resolved.
Also please be aware that the previous PR is not merged into any branch!