### PR TITLE
Fix handling relative paths in module manifests

### DIFF
--- a/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader.Abstractions/NativeManifestDetails.cs
+++ b/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader.Abstractions/NativeManifestDetails.cs
@@ -16,7 +16,7 @@ namespace MorganStanley.ComposeUI.ModuleLoader;
 
 public sealed class NativeManifestDetails
 {
-    public Uri Path { get; init; }
+    public Uri Path { get; set; }
     public Uri? Icon { get; init; }
     public string[] Arguments { get; init; } = Array.Empty<string>();
     public Dictionary<string, string> EnvironmentVariables { get; init; } = new Dictionary<string, string>();

--- a/src/shell/dotnet/Shell/MainWindow.xaml.cs
+++ b/src/shell/dotnet/Shell/MainWindow.xaml.cs
@@ -16,7 +16,6 @@ using System.IO;
 using System.Windows;
 using System.Windows.Controls.Ribbon;
 using CommunityToolkit.Mvvm.ComponentModel;
-using Infragistics.Windows.DockManager;
 using MorganStanley.ComposeUI.ModuleLoader;
 using MorganStanley.ComposeUI.Shell.ImageSource;
 using MorganStanley.ComposeUI.Shell.Utilities;
@@ -112,14 +111,18 @@ public partial class MainWindow : RibbonWindow
             }
             else if (manifest.TryGetDetails<NativeManifestDetails>(out var nativeManifestDetails))
             {
-                using var icon =
-                    System.Drawing.Icon.ExtractAssociatedIcon(Path.GetFullPath(nativeManifestDetails.Path.ToString()));
-
-                if (icon != null)
+                var path = nativeManifestDetails.Path.IsAbsoluteUri ? nativeManifestDetails.Path.AbsolutePath : nativeManifestDetails.Path.ToString();
+                if (File.Exists(path))
                 {
-                    using var bitmap = icon.ToBitmap();
+                    using var icon =
+                        System.Drawing.Icon.ExtractAssociatedIcon(path);
 
-                    ImageSource = bitmap.ToImageSource();
+                    if (icon != null)
+                    {
+                        using var bitmap = icon.ToBitmap();
+
+                        ImageSource = bitmap.ToImageSource();
+                    }
                 }
             }
         }

--- a/src/shell/dotnet/examples/module-catalog.json
+++ b/src/shell/dotnet/examples/module-catalog.json
@@ -58,7 +58,7 @@
     "Name": "Diagnostics WPF",
     "ModuleType": "native",
     "Details": {
-      "Path": "..\\..\\..\\..\\..\\..\\..\\examples\\dotnet-diagnostics\\DiagnosticsExample\\bin\\Debug\\net6.0-windows\\DiagnosticsExample.exe",
+      "Path": "..\\..\\..\\..\\examples\\dotnet-diagnostics\\DiagnosticsExample\\bin\\Debug\\net6.0-windows\\DiagnosticsExample.exe",
       "EnvironmentVariables": { "CUSTOM_GREETINGS": "Hello ComposeUI!" }
     }
   },


### PR DESCRIPTION
- For native modules instead of treating relative paths as relative to the current working directory treat them as relative to the path of the module catalog json file