### PR TITLE
Improvements for fdc3.open()

### DIFF
--- a/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/Fdc3DesktopAgent.cs
+++ b/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/Fdc3DesktopAgent.cs
@@ -719,8 +719,7 @@ internal class Fdc3DesktopAgent : IFdc3DesktopAgentBridge
         }
     }
 
-    //TODO: https://github.com/finos/FDC3/issues/1350
-    //Queueing up open context, deliver that first, after that we should send other contexts.
+    //https://github.com/finos/FDC3/issues/1350
     public async ValueTask<OpenResponse?> Open(OpenRequest? request, IContext? context = null)
     {
         if (request == null)
@@ -794,12 +793,9 @@ internal class Fdc3DesktopAgent : IFdc3DesktopAgentBridge
             return ValueTask.FromResult<GetOpenedAppContextResponse?>(GetOpenedAppContextResponse.Failure(Fdc3DesktopAgentErrors.IdNotParsable));
         }
 
-        if (!_openedAppContexts.TryRemove(contextId, out var context))
-        {
-            return ValueTask.FromResult<GetOpenedAppContextResponse?>(GetOpenedAppContextResponse.Failure(Fdc3DesktopAgentErrors.OpenedAppContextNotFound));
-        }
-
-        return ValueTask.FromResult<GetOpenedAppContextResponse?>(GetOpenedAppContextResponse.Success(context));
+        return !_openedAppContexts.TryRemove(contextId, out var context) 
+            ? ValueTask.FromResult<GetOpenedAppContextResponse?>(GetOpenedAppContextResponse.Failure(Fdc3DesktopAgentErrors.OpenedAppContextNotFound)) 
+            : ValueTask.FromResult<GetOpenedAppContextResponse?>(GetOpenedAppContextResponse.Success(context));
     }
 
     public async ValueTask<RaiseIntentResult<RaiseIntentResponse>> RaiseIntentForContext(RaiseIntentForContextRequest? request, IContext context)

--- a/src/fdc3/dotnet/DesktopAgent/test/MorganStanley.ComposeUI.DesktopAgent.Tests/EndToEndTests.cs
+++ b/src/fdc3/dotnet/DesktopAgent/test/MorganStanley.ComposeUI.DesktopAgent.Tests/EndToEndTests.cs
@@ -934,7 +934,7 @@ public class EndToEndTests : IAsyncLifetime
             MessageBuffer.Factory.CreateJson(request, _options));
         var result = response?.ReadJson<CreateAppChannelResponse>(_options);
 
-        result.Should().BeEquivalentTo(CreateAppChannelResponse.Failed(ChannelError.CreationFailed));
+        result.Should().BeEquivalentTo(CreateAppChannelResponse.Failed(Fdc3DesktopAgentErrors.PayloadNull));
     }
 
     [Fact]

--- a/src/fdc3/dotnet/DesktopAgent/test/MorganStanley.ComposeUI.DesktopAgent.Tests/Infrastructure/Internal/Fdc3DesktopAgentMessageRouterService.Tests.cs
+++ b/src/fdc3/dotnet/DesktopAgent/test/MorganStanley.ComposeUI.DesktopAgent.Tests/Infrastructure/Internal/Fdc3DesktopAgentMessageRouterService.Tests.cs
@@ -989,7 +989,7 @@ public class Fdc3DesktopAgentMessageRouterServiceTests : IAsyncLifetime
 
         var result = await _fdc3.HandleCreateAppChannel(request, new MessageContext());
 
-        result.Should().BeEquivalentTo(CreateAppChannelResponse.Failed(ChannelError.CreationFailed));
+        result.Should().BeEquivalentTo(CreateAppChannelResponse.Failed(Fdc3DesktopAgentErrors.PayloadNull));
     }
 
     [Fact]

--- a/src/fdc3/dotnet/DesktopAgent/test/MorganStanley.ComposeUI.DesktopAgent.Tests/Infrastructure/Internal/Fdc3DesktopAgentMessageRouterService.Tests.cs
+++ b/src/fdc3/dotnet/DesktopAgent/test/MorganStanley.ComposeUI.DesktopAgent.Tests/Infrastructure/Internal/Fdc3DesktopAgentMessageRouterService.Tests.cs
@@ -34,6 +34,7 @@ using IntentMetadata = MorganStanley.ComposeUI.Fdc3.DesktopAgent.Protocol.Intent
 using Icon = MorganStanley.ComposeUI.Fdc3.DesktopAgent.Protocol.Icon;
 using ImplementationMetadata = MorganStanley.ComposeUI.Fdc3.DesktopAgent.Protocol.ImplementationMetadata;
 using System.Collections.Concurrent;
+using System.Text.Json;
 
 namespace MorganStanley.ComposeUI.Fdc3.DesktopAgent.Tests.Infrastructure.Internal;
 
@@ -1683,6 +1684,145 @@ public class Fdc3DesktopAgentMessageRouterServiceTests : IAsyncLifetime
         response.Should().NotBeNull();
         response!.Success.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task HandleOpen_returns_PayloadNull_error()
+    {
+        OpenRequest? request = null;
+
+        var response = await _fdc3.HandleOpen(request, new());
+
+        response.Should().NotBeNull();
+        response!.Error.Should().Be(Fdc3DesktopAgentErrors.PayloadNull);
+    }
+
+    [Fact]
+    public async Task HandleOpen_returns_MissingId_error()
+    {
+        OpenRequest? request = new()
+        {
+            InstanceId = "NotExistentId"
+        };
+
+        var response = await _fdc3.HandleOpen(request, new());
+
+        response.Should().NotBeNull();
+        response!.Error.Should().Be(Fdc3DesktopAgentErrors.MissingId);
+    }
+
+    [Fact]
+    public async Task HandleOpen_returns_AppNotFound_error()
+    {
+        await _fdc3.StartAsync(CancellationToken.None);
+
+        //TODO: should add some identifier to the query => "fdc3:" + instance.Manifest.Id
+        var origin = await _mockModuleLoader.Object.StartModule(new StartRequest("appId1"));
+        var originFdc3InstanceId = Fdc3InstanceIdRetriever.Get(origin);
+        OpenRequest? request = new()
+        {
+            InstanceId = originFdc3InstanceId,
+            AppIdentifier = new AppIdentifier()
+            {
+                AppId = "NonExistentAppId"
+            }
+        };
+
+        var response = await _fdc3.HandleOpen(request, new());
+
+        response.Should().NotBeNull();
+        response!.Error.Should().Be(OpenError.AppNotFound);
+    }
+
+    [Fact]
+    public async Task HandleOpen_returns_AppTimeout_error_as_context_listener_is_not_registered()
+    {
+        await _fdc3.StartAsync(CancellationToken.None);
+
+        //TODO: should add some identifier to the query => "fdc3:" + instance.Manifest.Id
+        var origin = await _mockModuleLoader.Object.StartModule(new StartRequest("appId1"));
+        var originFdc3InstanceId = Fdc3InstanceIdRetriever.Get(origin);
+        OpenRequest? request = new()
+        {
+            InstanceId = originFdc3InstanceId,
+            AppIdentifier = new AppIdentifier()
+            {
+                AppId = "appId1"
+            },
+            Context = JsonSerializer.Serialize(new Context("fdc3.instrument"))
+        };
+
+        var response = await _fdc3.HandleOpen(request, new());
+
+        response.Should().NotBeNull();
+        response!.Error.Should().Be(OpenError.AppTimeout);
+    }
+
+    [Fact]
+    public async Task HandleOpen_returns_without_context()
+    {
+        await _fdc3.StartAsync(CancellationToken.None);
+
+        //TODO: should add some identifier to the query => "fdc3:" + instance.Manifest.Id
+        var origin = await _mockModuleLoader.Object.StartModule(new StartRequest("appId1"));
+        var originFdc3InstanceId = Fdc3InstanceIdRetriever.Get(origin);
+
+        OpenRequest? request = new()
+        {
+            InstanceId = originFdc3InstanceId,
+            AppIdentifier = new AppIdentifier
+            {
+                AppId = "appId1"
+            }
+        };
+
+        var response = await _fdc3.HandleOpen(request, new());
+
+        response.Should().NotBeNull();
+        response!.Error.Should().BeNull();
+        response!.AppIdentifier.Should().NotBeNull();
+        response!.AppIdentifier!.AppId.Should().Be("appId1");
+        response!.AppIdentifier!.InstanceId.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task HandleGetOpenedAppContext_returns_PayloadNull_error()
+    {
+        GetOpenedAppContextRequest? request = null;
+
+        var response = await _fdc3.HandleGetOpenedAppContext(request, new());
+
+        response.Should().NotBeNull();
+        response!.Error.Should().Be(Fdc3DesktopAgentErrors.PayloadNull);
+    }
+
+    [Fact]
+    public async Task HandleGetOpenedAppContext_returns_IdNotParsable_error()
+    {
+        GetOpenedAppContextRequest? request = new()
+        {
+            ContextId = "NotValidId"
+        };
+
+        var response = await _fdc3.HandleGetOpenedAppContext(request, new());
+
+        response.Should().NotBeNull();
+        response!.Error.Should().Be(Fdc3DesktopAgentErrors.IdNotParsable);
+    }
+
+    [Fact]
+    public async Task HandleGetOpenedAppContext_returns_ContextNotFound_error()
+    {
+        GetOpenedAppContextRequest? request = new()
+        {
+            ContextId = Guid.NewGuid().ToString(),
+        };
+
+        var response = await _fdc3.HandleGetOpenedAppContext(request, new());
+
+        response.Should().NotBeNull();
+        response!.Error.Should().Be(Fdc3DesktopAgentErrors.OpenedAppContextNotFound);
+    }
+
 
     [Theory]
     [ClassData(typeof(FindIntentTheoryData))]

--- a/src/fdc3/js/composeui-fdc3/src/ComposeUIChannel.spec.ts
+++ b/src/fdc3/js/composeui-fdc3/src/ComposeUIChannel.spec.ts
@@ -43,7 +43,10 @@ describe('Tests for ComposeUIChannel implementation API', () => {
                     appId: "testAppId",
                     instanceId: "testInstanceId"
                 },
-                channelId : "test"
+                channelId : "test",
+                openAppIdentifier: {
+                    openedAppContextId: "test"
+                }
             }
         };
 
@@ -147,7 +150,6 @@ describe('Tests for ComposeUIChannel implementation API', () => {
     });
 
     // TODO: Test broadcast/getLastContext with different context and contextType combinations
-
     it('addContextListener will result a ComposeUIContextListener', async () => {
         await testChannel.broadcast(testInstrument);
         const resultListener = await testChannel.addContextListener('fdc3.instrument', contextMessageHandlerMock);
@@ -172,7 +174,10 @@ describe("AppChanel tests", () => {
                     appId: "testAppId",
                     instanceId: "testInstanceId"
                 },
-                channelId : "test"
+                channelId : "test",
+                openAppIdentifier: {
+                    openedAppContextId: "test"
+                }
             }
         };
     });

--- a/src/fdc3/js/composeui-fdc3/src/ComposeUIContextListener.spec.ts
+++ b/src/fdc3/js/composeui-fdc3/src/ComposeUIContextListener.spec.ts
@@ -45,7 +45,10 @@ describe('Tests for ComposeUIContextListener implementation API', () => {
                     appId: "testAppId",
                     instanceId: "testInstanceId"
                 },
-                channelId : "test"
+                channelId : "test",
+                openAppIdentifier: {
+                    openedAppContextId: "test"
+                }
             }
         };
 

--- a/src/fdc3/js/composeui-fdc3/src/ComposeUIContextListener.spec.ts
+++ b/src/fdc3/js/composeui-fdc3/src/ComposeUIContextListener.spec.ts
@@ -74,7 +74,7 @@ describe('Tests for ComposeUIContextListener implementation API', () => {
                 .mockImplementationOnce(() => Promise.resolve(JSON.stringify({ context: "", payload: `${JSON.stringify(dummyContext)}` })))
         };
 
-        testListener = new ComposeUIContextListener(messageRouterClient, contextMessageHandlerMock, "fdc3.instrument");
+        testListener = new ComposeUIContextListener(true, messageRouterClient, contextMessageHandlerMock, "fdc3.instrument");
         await testListener.subscribe(dummyChannelId, "user");
     });
 
@@ -88,7 +88,7 @@ describe('Tests for ComposeUIContextListener implementation API', () => {
     });
 
     it('handleContextMessage will be rejected with Error if unsubscribed', async () => {
-        testListener = new ComposeUIContextListener(messageRouterClient, contextMessageHandlerMock, "fdc3.instrument");
+        testListener = new ComposeUIContextListener(true, messageRouterClient, contextMessageHandlerMock, "fdc3.instrument");
         testListener.unsubscribe();
         await expect(testListener.handleContextMessage(testInstrument))
             .rejects
@@ -99,5 +99,11 @@ describe('Tests for ComposeUIContextListener implementation API', () => {
         await expect(testListener.handleContextMessage(wrongContext))
             .rejects
             .toThrow(Error);
+    });
+
+    it('handleContextMessage wont call the handler as the context from the open call was not handled yet', async() => {
+        testListener.setOpenHandled(false);
+        await testListener.handleContextMessage(testInstrument);
+        expect(contextMessageHandlerMock).toHaveBeenCalledTimes(0);
     });
 });

--- a/src/fdc3/js/composeui-fdc3/src/ComposeUIDesktopAgent.spec.ts
+++ b/src/fdc3/js/composeui-fdc3/src/ComposeUIDesktopAgent.spec.ts
@@ -24,7 +24,7 @@ import { ComposeUIPrivateChannel } from './infrastructure/ComposeUIPrivateChanne
 import { ChannelType } from './infrastructure/ChannelType';
 
 const dummyContext = { type: "dummyContextType" };
-const dummyChannelId = "dummyId";
+const dummyChannelId = "dummy";
 let messageRouterClient: MessageRouter;
 let desktopAgent: DesktopAgent;
 
@@ -47,7 +47,10 @@ describe('Tests for ComposeUIDesktopAgent implementation API', () => {
                     appId: "testAppId",
                     instanceId: "testInstanceId"
                 },
-                channelId : "test"
+                channelId : "test",
+                openAppIdentifier: {
+                    openedAppContextId: "test"
+                }
             }
         };
 
@@ -123,10 +126,9 @@ describe('Tests for ComposeUIDesktopAgent implementation API', () => {
         expect(result).toMatchObject<Partial<Channel>>({ id: dummyChannelId, type: "user" });
     });
 
-    it('leaveCurrentChannel will trigger the current channel listeners to unsubscribe', async () => {
-        const listener = <ComposeUIContextListener>await desktopAgent.addContextListener("fdc3.instrument", contextMessageHandlerMock)
-
+    it('listener could not handle context message as its not subscribed', async () => {
         await desktopAgent.leaveCurrentChannel();
+        const listener = <ComposeUIContextListener>await desktopAgent.addContextListener("fdc3.instrument", contextMessageHandlerMock)
         var result = await desktopAgent.getCurrentChannel();
         expect(result).toBeFalsy();
         expect(listener.handleContextMessage(dummyContext))

--- a/src/fdc3/js/composeui-fdc3/src/ComposeUIDesktopAgent.ts
+++ b/src/fdc3/js/composeui-fdc3/src/ComposeUIDesktopAgent.ts
@@ -115,9 +115,7 @@ export class ComposeUIDesktopAgent implements DesktopAgent {
         // We call its handler after we go through the same process without queueing the received contexts.
         if (this.openedAppContext 
             && handler 
-            && (contextType == this.openedAppContext?.type || this.openedAppContext.type == null || !this.openedAppContext.type)) {
-                console.log("Calling the handler for the opened App context.");
-                
+            && (contextType == this.openedAppContext?.type || this.openedAppContext.type == null || !this.openedAppContext.type)) {                
                 if (!this.openedAppContextHandled) {
                     handler(this.openedAppContext);
                     this.openedAppContextHandled = true;
@@ -149,13 +147,14 @@ export class ComposeUIDesktopAgent implements DesktopAgent {
         let channel = this.userChannels.find(innerChannel => innerChannel.id == channelId);
         if (!channel) {
             channel = await this.channelFactory.joinUserChannel(channelId);
+            
+            if (!channel) {
+                throw new Error(ChannelError.NoChannelFound);
+            }
+    
+            this.addChannel(channel);
         }
 
-        if (!channel) {
-            throw new Error(ChannelError.NoChannelFound);
-        }
-
-        this.addChannel(channel);
         this.currentChannel = channel;
 
         for (const listener of this.topLevelContextListeners) {

--- a/src/fdc3/js/composeui-fdc3/src/ComposeUIDesktopAgent.ts
+++ b/src/fdc3/js/composeui-fdc3/src/ComposeUIDesktopAgent.ts
@@ -111,18 +111,22 @@ export class ComposeUIDesktopAgent implements DesktopAgent {
             contextType = null;
         }
 
-        //TODO: The opened app context now is received even though the DA is not joined to a userchannel. 
-        // We call its handler after we go through the same process without queueing the received contexts.
         if (this.openedAppContext 
             && handler 
             && (contextType == this.openedAppContext?.type || this.openedAppContext.type == null || !this.openedAppContext.type)) {                
-                if (!this.openedAppContextHandled) {
+                
+                if (this.openedAppContextHandled === false) {
                     handler(this.openedAppContext);
                     this.openedAppContextHandled = true;
                 }
+        } 
+        
+        if (!this.openedAppContext && this.openedAppContextHandled !== true) {
+            //There is no context to handle -aka app was not opened via the fdc3.open
+            this.openedAppContextHandled = true;
         }
 
-        const listener = <ComposeUIContextListener>await this.channelFactory.getContextListener(this.currentChannel, handler, contextType);
+        const listener = <ComposeUIContextListener>await this.channelFactory.getContextListener(this.openedAppContextHandled, this.currentChannel, handler, contextType);
         this.topLevelContextListeners.push(listener);
 
         if (!this.currentChannel) {

--- a/src/fdc3/js/composeui-fdc3/src/ComposeUIIntentHandling.spec.ts
+++ b/src/fdc3/js/composeui-fdc3/src/ComposeUIIntentHandling.spec.ts
@@ -30,7 +30,10 @@ describe("Tests for ComposeUIDesktopAgent's intent handling", () => {
                     appId: "testAppId",
                     instanceId: "testInstanceId"
                 },
-                channelId : "test"
+                channelId : "test",
+                openAppIdentifier: {
+                    openedAppContextId: "test"
+                }
             }
         };
     });

--- a/src/fdc3/js/composeui-fdc3/src/ComposeUIMessageRouterMetadataClient.spec.ts
+++ b/src/fdc3/js/composeui-fdc3/src/ComposeUIMessageRouterMetadataClient.spec.ts
@@ -25,7 +25,10 @@ describe('MessageRouterMetadataClient tests', () => {
                     appId: "testAppId",
                     instanceId: "testInstanceId"
                 },
-                channelId: "test"
+                channelId: "test",
+                openAppIdentifier: {
+                    openedAppContextId: "test"
+                }
             }
         };
     });

--- a/src/fdc3/js/composeui-fdc3/src/ComposeUIMessageRouterOpenClient.spec.ts
+++ b/src/fdc3/js/composeui-fdc3/src/ComposeUIMessageRouterOpenClient.spec.ts
@@ -1,0 +1,239 @@
+/* 
+ *  Morgan Stanley makes this available to you under the Apache License,
+ *  Version 2.0 (the "License"). You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0.
+ *  See the NOTICE file distributed with this work for additional information
+ *  regarding copyright ownership. Unless required by applicable law or agreed
+ *  to in writing, software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ *  or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { getCurrentChannel, OpenError } from "@finos/fdc3";
+import { MessageRouterOpenClient } from "./infrastructure/MessageRouterOpenClient";
+import { ComposeUIErrors } from "./infrastructure/ComposeUIErrors";
+import { Fdc3OpenResponse } from "./infrastructure/messages/Fdc3OpenResponse";
+import { MessageRouter } from "@morgan-stanley/composeui-messaging-client";
+import { Fdc3GetOpenedAppContextResponse } from "./infrastructure/messages/Fdc3GetOpenedAppContextResponse";
+import { OpenAppIdentifier } from "./infrastructure/OpenAppIdentifier";
+import { rejects } from "assert";
+
+describe('MessageRouter OpenClient tests', () => {
+    let client: MessageRouterOpenClient;
+    let messageRouterClient: MessageRouter;
+    const openAppIdentifier: OpenAppIdentifier = { openedAppContextId: "contextId" };
+
+    beforeEach(() => {
+        window.composeui = {
+            fdc3: {
+                config: {
+                    appId: "testAppId",
+                    instanceId: "testInstanceId"
+                },
+                channelId: "test",
+                openAppIdentifier: {
+                    openedAppContextId: "contextId"
+                }
+            }
+        };
+
+        messageRouterClient = {
+            clientId: "dummy",
+            subscribe: jest.fn(() => {
+                return Promise.resolve({ unsubscribe: () => { } });
+            }),
+
+            publish: jest.fn(() => { return Promise.resolve() }),
+            connect: jest.fn(() => { return Promise.resolve() }),
+            registerEndpoint: jest.fn(() => { return Promise.resolve() }),
+            unregisterEndpoint: jest.fn(() => { return Promise.resolve() }),
+            registerService: jest.fn(() => { return Promise.resolve() }),
+            unregisterService: jest.fn(() => { return Promise.resolve() }),
+            invoke: jest.fn(() => { return Promise.resolve(undefined) })
+        };
+
+        client = new MessageRouterOpenClient("fdc3InstanceId", messageRouterClient, openAppIdentifier);
+    });
+
+    it('open throws AppNotFound error as AppIdentifier not set', async() => {
+        await expect(client.open())
+            .rejects
+            .toThrow(OpenError.AppNotFound);
+    });
+
+    it('open throws NoAnswerWasProvided error as no response received by the MessageRouter server', async() => {
+        await expect(client.open("appId1"))
+            .rejects
+            .toThrow(ComposeUIErrors.NoAnswerWasProvided);
+    });
+
+    it('open throws error as error response received by the MessageRouter server', async() => {
+        const response: Fdc3OpenResponse = {
+            error: "testError"
+        };
+
+        messageRouterClient = {
+            clientId: "dummy",
+            subscribe: jest.fn(() => {
+                return Promise.resolve({ unsubscribe: () => { } });
+            }),
+
+            publish: jest.fn(() => { return Promise.resolve() }),
+            connect: jest.fn(() => { return Promise.resolve() }),
+            registerEndpoint: jest.fn(() => { return Promise.resolve() }),
+            unregisterEndpoint: jest.fn(() => { return Promise.resolve() }),
+            registerService: jest.fn(() => { return Promise.resolve() }),
+            unregisterService: jest.fn(() => { return Promise.resolve() }),
+            invoke: jest.fn(() => { return Promise.resolve(`${JSON.stringify(response)}`) })
+        };
+
+        client = new MessageRouterOpenClient("fdc3InstanceId", messageRouterClient, openAppIdentifier);
+        await expect(client.open("appId1"))
+            .rejects
+            .toThrow("testError");
+    });
+
+    it('open returns AppIdentifier response received by the MessageRouter server', async() => {
+        const response: Fdc3OpenResponse = {
+            appIdentifier: {
+                appId: "appId1",
+                instanceId: "instanceId1"
+            }
+        };
+
+        messageRouterClient = {
+            clientId: "dummy",
+            subscribe: jest.fn(() => {
+                return Promise.resolve({ unsubscribe: () => { } });
+            }),
+
+            publish: jest.fn(() => { return Promise.resolve() }),
+            connect: jest.fn(() => { return Promise.resolve() }),
+            registerEndpoint: jest.fn(() => { return Promise.resolve() }),
+            unregisterEndpoint: jest.fn(() => { return Promise.resolve() }),
+            registerService: jest.fn(() => { return Promise.resolve() }),
+            unregisterService: jest.fn(() => { return Promise.resolve() }),
+            invoke: jest.fn(() => { return Promise.resolve(`${JSON.stringify(response)}`) })
+        }
+
+        client = new MessageRouterOpenClient("fdc3InstanceId", messageRouterClient, openAppIdentifier);
+        const result = await client.open({appId: "appId1"}, {type: "fdc3.instrument"});
+        expect(result).toMatchObject({appId: "appId1", instanceId: "instanceId1"});
+    });
+
+    it('getOpenedAppContext throws error as context id is not set', async() => {
+        client = new MessageRouterOpenClient("fdc3InstanceId", messageRouterClient);
+        await expect(client.getOpenedAppContext())
+            .rejects
+            .toThrow("Context id is not defined on the window object.");
+    });
+
+    it('getOpenedAppContext throws NoAnswerWasProvided error as no response received from the MessageRouter server', async() => {
+        await expect(client.getOpenedAppContext())
+            .rejects
+            .toThrow(ComposeUIErrors.NoAnswerWasProvided);
+    });
+
+    it('getOpenedAppContext throws NoAnswerWasProvided error as not correct response received from the MessageRouter server', async() => {
+        const response = {
+            payload: "wrongPayload"
+        };
+
+        messageRouterClient = {
+            clientId: "dummy",
+            subscribe: jest.fn(() => {
+                return Promise.resolve({ unsubscribe: () => { } });
+            }),
+
+            publish: jest.fn(() => { return Promise.resolve() }),
+            connect: jest.fn(() => { return Promise.resolve() }),
+            registerEndpoint: jest.fn(() => { return Promise.resolve() }),
+            unregisterEndpoint: jest.fn(() => { return Promise.resolve() }),
+            registerService: jest.fn(() => { return Promise.resolve() }),
+            unregisterService: jest.fn(() => { return Promise.resolve() }),
+            invoke: jest.fn(() => { return Promise.resolve(`${JSON.stringify(response)}`) })
+        };
+
+        client = new MessageRouterOpenClient("fdc3InstanceId", messageRouterClient, openAppIdentifier);
+        await expect(client.getOpenedAppContext())
+            .rejects
+            .toThrow(ComposeUIErrors.NoAnswerWasProvided);
+    });
+
+    it('getOpenedAppContext throws error as error response received from the MessageRouter server', async() => {
+        const response: Fdc3GetOpenedAppContextResponse = {
+            error: "testGetOpenedAppContextError"
+        };
+
+        messageRouterClient = {
+            clientId: "dummy",
+            subscribe: jest.fn(() => {
+                return Promise.resolve({ unsubscribe: () => { } });
+            }),
+
+            publish: jest.fn(() => { return Promise.resolve() }),
+            connect: jest.fn(() => { return Promise.resolve() }),
+            registerEndpoint: jest.fn(() => { return Promise.resolve() }),
+            unregisterEndpoint: jest.fn(() => { return Promise.resolve() }),
+            registerService: jest.fn(() => { return Promise.resolve() }),
+            unregisterService: jest.fn(() => { return Promise.resolve() }),
+            invoke: jest.fn(() => { return Promise.resolve(`${JSON.stringify(response)}`) })
+        };
+
+        client = new MessageRouterOpenClient("fdc3InstanceId", messageRouterClient, openAppIdentifier);
+        await expect(client.getOpenedAppContext())
+            .rejects
+            .toThrow("testGetOpenedAppContextError");
+    });
+
+    it('getOpenedAppContext throws NoAnswerWasProvided error as no context response received from the MessageRouter server', async() => {
+        const response: Fdc3GetOpenedAppContextResponse = { };
+
+        messageRouterClient = {
+            clientId: "dummy",
+            subscribe: jest.fn(() => {
+                return Promise.resolve({ unsubscribe: () => { } });
+            }),
+
+            publish: jest.fn(() => { return Promise.resolve() }),
+            connect: jest.fn(() => { return Promise.resolve() }),
+            registerEndpoint: jest.fn(() => { return Promise.resolve() }),
+            unregisterEndpoint: jest.fn(() => { return Promise.resolve() }),
+            registerService: jest.fn(() => { return Promise.resolve() }),
+            unregisterService: jest.fn(() => { return Promise.resolve() }),
+            invoke: jest.fn(() => { return Promise.resolve(`${JSON.stringify(response)}`) })
+        };
+
+        client = new MessageRouterOpenClient("fdc3InstanceId", messageRouterClient, openAppIdentifier);
+        await expect(client.getOpenedAppContext())
+            .rejects
+            .toThrow(ComposeUIErrors.NoAnswerWasProvided);
+    });
+
+    it('getOpenedAppContext returns context', async() => {
+        const response: Fdc3GetOpenedAppContextResponse = {
+            context: JSON.stringify({type: "fdc3.instrument"})
+        };
+
+        messageRouterClient = {
+            clientId: "dummy",
+            subscribe: jest.fn(() => {
+                return Promise.resolve({ unsubscribe: () => { } });
+            }),
+
+            publish: jest.fn(() => { return Promise.resolve() }),
+            connect: jest.fn(() => { return Promise.resolve() }),
+            registerEndpoint: jest.fn(() => { return Promise.resolve() }),
+            unregisterEndpoint: jest.fn(() => { return Promise.resolve() }),
+            registerService: jest.fn(() => { return Promise.resolve() }),
+            unregisterService: jest.fn(() => { return Promise.resolve() }),
+            invoke: jest.fn(() => { return Promise.resolve(`${JSON.stringify(response)}`) })
+        };
+
+        client = new MessageRouterOpenClient("fdc3InstanceId", messageRouterClient, openAppIdentifier);
+        const result = await client.getOpenedAppContext();
+
+        expect(result.type).toBe("fdc3.instrument");
+    });
+});

--- a/src/fdc3/js/composeui-fdc3/src/index.ts
+++ b/src/fdc3/js/composeui-fdc3/src/index.ts
@@ -40,7 +40,6 @@ async function initialize(): Promise<void> {
         await fdc3.joinUserChannel(channelId)
             .then(async() => {
                 if (openAppIdentifier) {
-                    console.log("CALLING GET OPENED APP CONTEXT.");
                     await fdc3.getOpenedAppContext()
                         .then(() => {
                             window.fdc3 = fdc3;

--- a/src/fdc3/js/composeui-fdc3/src/infrastructure/ChannelFactory.ts
+++ b/src/fdc3/js/composeui-fdc3/src/infrastructure/ChannelFactory.ts
@@ -21,5 +21,5 @@ export interface ChannelFactory {
     joinUserChannel(channelId: string): Promise<Channel>;
     getUserChannels(): Promise<Channel[]>;
     getIntentListener(intent: string, handler: IntentHandler): Promise<Listener>;
-    getContextListener(channel?: Channel, handler?: ContextHandler, contextType?: string | null): Promise<Listener>;
+    getContextListener(openHandled: boolean, channel?: Channel, handler?: ContextHandler, contextType?: string | null): Promise<Listener>;
 }

--- a/src/fdc3/js/composeui-fdc3/src/infrastructure/ComposeUIChannel.ts
+++ b/src/fdc3/js/composeui-fdc3/src/infrastructure/ComposeUIChannel.ts
@@ -41,9 +41,6 @@ export class ComposeUIChannel implements Channel {
         this.lastContext = context;
         const topic = ComposeUITopic.broadcast(this.id, this.type);
         await this.messageRouterClient.publish(topic, JSON.stringify(context));
-        
-        //TODO:Remove
-        console.log("Broadcasted on channel:", this.id, ", context:", context, ", on topic: ", topic, ", time: ", new Date().toISOString());
     }
 
     public async getCurrentContext(contextType?: string | undefined): Promise<Context | null> {
@@ -54,8 +51,6 @@ export class ComposeUIChannel implements Channel {
             if (context) {
                 this.lastContext = context;
                 this.lastContexts.set(context.type, context);
-
-                return context;
             }
         }
         return this.retrieveCurrentContext(contextType);

--- a/src/fdc3/js/composeui-fdc3/src/infrastructure/ComposeUIChannel.ts
+++ b/src/fdc3/js/composeui-fdc3/src/infrastructure/ComposeUIChannel.ts
@@ -26,6 +26,7 @@ export class ComposeUIChannel implements Channel {
     protected messageRouterClient: MessageRouter;
     private lastContexts: Map<string, Context> = new Map<string, Context>();
     private lastContext?: Context;
+    private openHandled: boolean = true; //by default true so if a channel was created then it has no effect
 
     constructor(id: string, type: ChannelType, messageRouterClient: MessageRouter, displayMetadata?: DisplayMetadata) {
         this.id = id;
@@ -75,8 +76,12 @@ export class ComposeUIChannel implements Channel {
             contextType = null;
         }
 
-        const listener = new ComposeUIContextListener(this.messageRouterClient, handler, contextType);
+        const listener = new ComposeUIContextListener(this.openHandled, this.messageRouterClient, handler, contextType);
         await listener.subscribe(this.id, this.type);
         return listener;
+    }
+
+    public setOpenHandled(openHandled: boolean): void {
+        this.openHandled = openHandled;
     }
 }

--- a/src/fdc3/js/composeui-fdc3/src/infrastructure/ComposeUIContextListener.ts
+++ b/src/fdc3/js/composeui-fdc3/src/infrastructure/ComposeUIContextListener.ts
@@ -46,20 +46,13 @@ export class ComposeUIContextListener implements Listener {
                 return;
             }
 
-            //TODO:Remove
-            console.log("Context message received, to handle:", topicMessage.payload, ", at:", new Date().toISOString());
-
             //TODO: integration test
             const context = <Context>JSON.parse(topicMessage.payload!);
             if (!this.contextType || this.contextType == context!.type) {
-                console.log("ComposeUIContextListener's handler is being called:", this.contextType, ", at: ", new Date().toISOString());
                 this.handler!(context!);
             }
         });
         this.isSubscribed = true;
-
-        //TODO:Remove
-        console.log("ContextListener is subscribed to topic:", subscribeTopic, ", contextType: ", this.contextType, "time:", new Date().toISOString());
     }
 
     public async handleContextMessage(context: Context): Promise<void> {
@@ -67,7 +60,6 @@ export class ComposeUIContextListener implements Listener {
             throw new Error("The current listener is not subscribed.");
         }
 
-        console.log("The current contextType: ", this.contextType);
         if (this.contextType && this.contextType != null && this.contextType != context.type) {
             throw new Error(`The current listener is not able to handle context type ${context.type}. It is registered to handle ${this.contextType}.`)
         }

--- a/src/fdc3/js/composeui-fdc3/src/infrastructure/MessageRouterChannelFactory.ts
+++ b/src/fdc3/js/composeui-fdc3/src/infrastructure/MessageRouterChannelFactory.ts
@@ -165,13 +165,18 @@ export class MessageRouterChannelFactory implements ChannelFactory {
         return listener;
     }
 
-    public async getContextListener(channel?: Channel, handler?: ContextHandler, contextType?: string | null): Promise<Listener> {
+    public async getContextListener(openHandled: boolean, channel?: Channel, handler?: ContextHandler, contextType?: string | null): Promise<Listener> {
         if (channel) {
+            
+            if (channel instanceof ComposeUIChannel){
+                (<ComposeUIChannel>channel).setOpenHandled(openHandled);
+            }
+            
             const listener = <ComposeUIContextListener>await channel.addContextListener(contextType ?? null, handler!);
             return listener;
         }
 
-        const listener = new ComposeUIContextListener(this.messageRouterClient, handler!, contextType ?? undefined);
+        const listener = new ComposeUIContextListener(openHandled, this.messageRouterClient, handler!, contextType ?? undefined);
         return listener;
     }
 }

--- a/src/fdc3/js/composeui-fdc3/src/infrastructure/MessageRouterOpenClient.ts
+++ b/src/fdc3/js/composeui-fdc3/src/infrastructure/MessageRouterOpenClient.ts
@@ -100,7 +100,6 @@ export class MessageRouterOpenClient implements OpenClient{
         }
 
         const context = <Context>JSON.parse(response.context);
-        console.log("RETRIEVED FROM CLIENT FOR THE OPENED APP: ", context);
         return context;
     }
 }

--- a/src/fdc3/js/composeui-fdc3/src/infrastructure/MessageRouterOpenClient.ts
+++ b/src/fdc3/js/composeui-fdc3/src/infrastructure/MessageRouterOpenClient.ts
@@ -45,7 +45,9 @@ export class MessageRouterOpenClient implements OpenClient{
             throw new Error(OpenError.MalformedContext);
         }
 
-        this.channel = await window.fdc3.getCurrentChannel();
+        if (window.fdc3) {
+            this.channel = await window.fdc3.getCurrentChannel();
+        }
 
         //TODO:proper context handling
         const request = new Fdc3OpenRequest(

--- a/src/fdc3/js/composeui-fdc3/src/infrastructure/OpenAppIdentifier.ts
+++ b/src/fdc3/js/composeui-fdc3/src/infrastructure/OpenAppIdentifier.ts
@@ -10,6 +10,9 @@
  *  and limitations under the License.
  */
 
+/**
+* This type stores the app's context id (given by the backend) which was opened via the `fdc3.open()` call.
+*/
 export interface OpenAppIdentifier {
     openedAppContextId?: string;
 }

--- a/src/messaging/js/composeui-messaging-client/src/client/MessageRouterClient.ts
+++ b/src/messaging/js/composeui-messaging-client/src/client/MessageRouterClient.ts
@@ -89,7 +89,6 @@ export class MessageRouterClient implements MessageRouter {
             topic: topicName
         });
 
-        console.log("MessageRouter Subscribe is executed:", topicName, ", topic: ", topic, ", at : ", new Date().toISOString());
         return subscription;
     }
 
@@ -104,15 +103,6 @@ export class MessageRouterClient implements MessageRouter {
                 payload,
                 correlationId: options?.correlationId
             });
-
-        console.log("MessageRouter publish message is sent: ", 
-        {
-            type: "Publish",
-            requestId: this.getRequestId(),
-            topic,
-            payload,
-            correlationId: options?.correlationId
-        }, ", at: ", new Date().toISOString());
     }
 
     async invoke(endpoint: string, payload?: MessageBuffer, options?: InvokeOptions): Promise<MessageBuffer | undefined> {


### PR DESCRIPTION
Fixed: 
- Fixed existing unit tests in our projects
- Removed added console.logs() for debugging purpose

Changed:
- Added unit tests in .Net and Typescript sides for fdc3.open call
- Improvements around caching the contexts -if the opened app's right context listener is not resolved the context received via the fdc3.open call we cache all the contexts until that context is resolved: https://github.com/finos/FDC3/issues/1350

Question: should we stop the module via module loader if the request fails but the start of the app was succesful? (e.g. context listener is not registered so AppTimeout happens) -> Conformance framework tests are closing the window if the request fails in this case.