### PR TITLE
chore(Workflows): Add workflow to update the Dependency Graph with CPM Nuget dependencies

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,27 @@
+name: Dependency Submission
+
+on:
+  workflow_dispatch:
+  schedule: 
+    - cron: 0 19 * * * #7 PM ET
+  
+
+permissions: 
+  id-token: write
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Components
+        run: |
+              npm i
+              npx lerna run build --stream
+              powershell ./build/dotnet-restore.ps1
+              powershell ./build/dotnet-build.ps1
+      - name: Component detection 
+        uses: advanced-security/component-detection-dependency-submission-action@v0.0.4
+        with:
+          detectorsFilter: "Npm,NuGet"


### PR DESCRIPTION
This workflow is collecting the Nuget Dependencies managed with CPM and updates the SBOM to the Dependency Graph API so that vulnerable dependencies can be picked up by Dependabot Alerts which then creates a PR to upgrade the vulnerable dependency.

The job is scheduled to run every day at 7PM ET and also can be run manually.

The component-detection-dependency-submission-action detects the dependencies after a build so it was necessary to add the minimal set of build steps to achieve a "quick build" before component detection. 