### PR TITLE
Using Promise.finally instead of setTimeout when returning ContextListener object

### DIFF
--- a/src/fdc3/js/composeui-fdc3/src/infrastructure/ComposeUIContextListener.ts
+++ b/src/fdc3/js/composeui-fdc3/src/infrastructure/ComposeUIContextListener.ts
@@ -52,7 +52,6 @@ export class ComposeUIContextListener implements Listener {
             //TODO: integration test
             const context = <Context>JSON.parse(topicMessage.payload!);
             if (!this.contextType || this.contextType == context!.type) {
-
                 if (this.openHandled === true) {
                     this.handler!(context!);
                 } else {


### PR DESCRIPTION
- Removed `setTimeout` using from the `DesktopAgent` implementation when we wanted to call the `getCurrentContext` on the `Listener` object after we had returned it from the `addContextListener` API call or if the `context listener` is joining to a `user channel`

![image](https://github.com/user-attachments/assets/c63fe9be-b1d2-4685-9430-0b33ac588a92)
![image](https://github.com/user-attachments/assets/ab48cc60-d42b-4b44-b7ae-108a6a374951)

