### PR TITLE
chore(deps): Prevent Upgrades to FluentAssertions 8.0.0 or higher

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,8 +7,8 @@
     <PackageVersion Include="Finos.Fdc3" Version="2.1.0" />
     <PackageVersion Include="Finos.Fdc3.NewtonsoftJson" Version="2.0.0" />
     <PackageVersion Include="Finos.Fdc3.AppDirectory" Version="2.1.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="FluentAssertions.Json" Version="6.1.0" />
+	<PackageVersion Include="FluentAssertions" Version="[6.12.0, 8.0)"/>
+	<PackageVersion Include="FluentAssertions.Json" Version="[6.1.0, 8.0)" />
     <PackageVersion Include="Google.Protobuf" Version="3.27.3" />
     <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.65.0" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.62.0" />


### PR DESCRIPTION
FluentAssertions has changed the License Agreement from Apache 2.0 to a paid one since version 8.0.0, so we only allow the project to upgrade to major version 7.x.