### PR TITLE
chore(workflows\dependency-submission): Remove detectorsFilter to catch all of the components

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -23,5 +23,3 @@ jobs:
               powershell ./build/dotnet-build.ps1
       - name: Component detection 
         uses: advanced-security/component-detection-dependency-submission-action@v0.0.4
-        with:
-          detectorsFilter: "Npm,NuGet"


### PR DESCRIPTION
This is an attempt to fix the issue that we've experienced after the 2nd scheduled run of this workflow as it was not detecting CPM packages after two successful runs.
The filter seems to look for an exact match among the Component Detector Ids, so it can potentially miss _"NuGetPackageReferenceFrameworkAware (Beta)"_, _"NuGetPackagesConfig"_ and _"NuGetProjectCentric"_