### PR TITLE
Node.js v22 Upgrade

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,7 @@ Accessing them can be done via the vars object.
 | Variable       | Description                                             | Example value |
 | -------------- | ------------------------------------------------------- | ------------- |
 | DOTNET_VERSION | The version of dotnet to load with actions/setup-dotnet | 8.0.x         |
-| NODE_VERSION   | The version of node.js to load with actions/setup-node  | 18.x          |
+| NODE_VERSION   | The version of node.js to load with actions/setup-node  | 22.x          |
 
 # Workflows
 ## continous-integration.yml

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         dotnet-version: [ '8.0.x' ]
-        node-version: [ '20.x' ]
+        node-version: [ '22.x' ]
     steps:
     - name: Checkout
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: https://registry.npmjs.org/
       - run: |
              lerna publish from-package --no-private --yes

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It supports desktop and web applications in order to provide an evergreen altern
 
 # Development Setup
 ## Prerequisites
-* Node.js 18
+* Node.js 22
 * .NET 8 (SDK 8.0.x, Desktop Runtime 8.0.x)
 * Visual Studio 2022 Community Edition
 

--- a/src/messaging/js/composeui-messaging-client/rollup.config.js
+++ b/src/messaging/js/composeui-messaging-client/rollup.config.js
@@ -13,7 +13,7 @@
 
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
-import pkg from "./package.json" assert { type: "json" };
+import pkg from "./package.json" with { type: "json" };
 
 const moduleName = pkg.name.replace(/^@.*\//, "");
 const inputFileName = "src/index.ts";

--- a/src/shell/js/composeui-node-launcher/src/cli/install.js
+++ b/src/shell/js/composeui-node-launcher/src/cli/install.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-"use strict";
 
 import path from 'path';
 import fs from 'fs';
@@ -12,7 +11,7 @@ import extract from 'extract-zip';
 import * as stream from 'stream';
 import { promisify } from 'util';
 
-import pkg from './../../package.json' assert { type: "json" };
+import pkg from './../../package.json' with  { type: "json" };
 
 const DEFAULT_CDN_URL = 'https://github.com/morganstanley/ComposeUI/releases/download';
 

--- a/src/shell/js/composeui-node-launcher/src/launcher.ts
+++ b/src/shell/js/composeui-node-launcher/src/launcher.ts
@@ -3,7 +3,7 @@ import { WindowConfig } from './windowConfig';
 import { fileURLToPath } from "node:url";
 
 export class Launcher {
-    private composeuiBinaryFileName = process.platform === 'win32' ? 'ComposeUI-Shell.exe' : 'ComposeUI-Shell'; 
+    private composeuiBinaryFileName = process.platform === 'win32' ? 'MorganStanley.ComposeUI.Shell.exe' : 'MorganStanley.ComposeUI.Shell'; 
     private composeuiBinaryFilePath = process.env.npm_config_composeui_binary_file_path || process.env.COMPOSEUI_BINARY_FILE_PATH || fileURLToPath(new URL(`./../dist/${this.composeuiBinaryFileName}`, import.meta.url));   
 
     private processArgs(config?: WindowConfig) {


### PR DESCRIPTION
This PR upgrades packages and CI workflows to build on Node.js 22.
[Node.js 22 has replaced the 'assert' syntax with 'with'](https://github.com/nodejs/node/issues/51622)
which had an impact on the packaging for 2 of our libraries:
1. MessageRouter JS Client
- [x] Tested Successfully with pricing example (Shell built both on .NET 6 and .NET 8 yielded the same results)
2. Node.js Launcher
- [x] Tested Successfully with Node.js Launcher example (Shell built both on .NET 6 and .NET 8 yielded the same results)

**Changes in this PR:**
* chore(composeui-node-launcher): Upgrade Node.js to v22
* chore(messaging/js-client): Upgrade to Node.js v22
* chore(workflows): Upgrade CI and Release workflows to Node.js v22
* chore(documentation): Update README Files to Reflect Node.js 22 Upgrade
* fix(node-launcher): Fix binary Filename