### PR TITLE
chore(CI): Run CI for any Pull Request

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
This change allows the CI build to kick off on any open PR regardless of the target branch.
This ensures the code quality of our temporal feature/prototype branches.