### PR TITLE
fix(examples/fdc3-chart-and-grid): Remove Location Alterations from PS Script

### DIFF
--- a/examples/fdc3-chart-and-grid/serve-chart-and-grid.ps1
+++ b/examples/fdc3-chart-and-grid/serve-chart-and-grid.ps1
@@ -1,6 +1,3 @@
-Push-Location .
-Set-Location $PSScriptRoot\..
 npm i
 npx lerna run build --stream --scope "{@morgan-stanley/composeui-example-chart,@morgan-stanley/composeui-example-grid}"
 npx lerna run start --stream --scope "{@morgan-stanley/composeui-example-chart,@morgan-stanley/composeui-example-grid}"
-Pop-Location


### PR DESCRIPTION
Since lerna@8.1.9 when we try to run the PS script "examples/fdc3-chart-and-grid/serve-chart-and-grid.ps1" that serves the example we get the following error:

```Run `npm audit` for details.
lerna notice cli v8.1.9
lerna ERR! ENOPKG `package.json` does not exist, have you run `lerna init`?```

In case of lerna@8.1.8 this didn't occurred.
Removing `Push-Location .` and `Set-Location $PSScriptRoot\.. ` has resolved the issue