### PR TITLE
Fix example ps scripts

### DIFF
--- a/examples/fdc3-pricing-and-chat/serve-pricing-and-chat.ps1
+++ b/examples/fdc3-pricing-and-chat/serve-pricing-and-chat.ps1
@@ -1,6 +1,3 @@
-Push-Location .
-Set-Location $PSScriptRoot\..
 npm i
 npx lerna run build --stream --scope "{@morgan-stanley/composeui-example-pricing,@morgan-stanley/composeui-example-chat}"
 npx lerna run start --stream --scope "{@morgan-stanley/composeui-example-pricing,@morgan-stanley/composeui-example-chat}"
-Pop-Location

--- a/examples/fdc3-trade-simulator/serve-trading-simulation-apps.ps1
+++ b/examples/fdc3-trade-simulator/serve-trading-simulation-apps.ps1
@@ -1,6 +1,3 @@
-Push-Location .
-Set-Location $PSScriptRoot\..
 npm i
 npx lerna run build --stream --scope "{@morgan-stanley/composeui-example-trader-app,@morgan-stanley/composeui-example-order-book}"
 npx lerna run start --stream --scope "{@morgan-stanley/composeui-example-trader-app,@morgan-stanley/composeui-example-order-book}"
-Pop-Location

--- a/examples/js-chart-and-grid-messagerouter/serve-chart-and-grid.ps1
+++ b/examples/js-chart-and-grid-messagerouter/serve-chart-and-grid.ps1
@@ -1,6 +1,3 @@
-Push-Location .
-Set-Location $PSScriptRoot\..\..
 npm i
 npx lerna run build --stream --scope "{@morgan-stanley/composeui-example-chart-messagerouter,@morgan-stanley/composeui-example-grid-messagerouter}"
 npx lerna run start --stream --scope "{@morgan-stanley/composeui-example-chart-messagerouter,@morgan-stanley/composeui-example-grid-messagerouter}"
-Pop-Location


### PR DESCRIPTION
Since lerna@8.1.9 when we try to run the PS scripts that serve the examples we get the following error for each:

```Run `npm audit` for details.
lerna notice cli v8.1.9
lerna ERR! ENOPKG `package.json` does not exist, have you run `lerna init`?```

In case of lerna@8.1.8 this didn't occurred.
Removing `Push-Location .` and `Set-Location $PSScriptRoot\.. ` has resolved the issue