### PR TITLE
Update CI and release configs to .NET 8.0.x

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        dotnet-version: [ '6.0.x' ]
+        dotnet-version: [ '8.0.x' ]
         node-version: [ '20.x' ]
     steps:
     - name: Checkout
@@ -83,4 +83,4 @@ jobs:
       uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
       with:
         name: shell-binaries
-        path: ${{ github.workspace }}/src/shell/dotnet/Shell/bin/Release/net6.0-windows/
+        path: ${{ github.workspace }}/src/shell/dotnet/Shell/bin/Release/net8.0-windows/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           path: ./packages
       - uses: actions/setup-dotnet@6bd8b7f7774af54e05809fcc5431931b3eb1ddee # v4.0.1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Publish Messaging packages
         working-directory: ./packages
         run: |


### PR DESCRIPTION
Updated the `continuous-integration.yml` and `release.yml` files to use .NET version 8.0.x instead of 6.0.x. Adjusted the path for uploading shell binaries to `net8.0-windows`.