### PR TITLE
Downgrade FDC3 Examples and Prevent Upgrades to 2.1 Packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
     directory: '/src/fdc3/dotnet/DesktopAgent/src/DesktopAgent'
     schedule:
       interval: 'monthly'
+      ignore:
+        - dependency-name: 'Finos.Fdc3*'
+          versions: [ '>=2.1' ]
     groups:
       infragistics:
         patterns:
@@ -105,6 +108,9 @@ updates:
     directory: '/'
     schedule:
       interval: 'monthly'
+      ignore:
+        - dependency-name: '@finos/fdc3'
+          versions: [ '>=2.1' ]
     groups:
       react:
         patterns:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,9 +4,9 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.3" />
     <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
-    <PackageVersion Include="Finos.Fdc3" Version="2.0.0" />
-    <PackageVersion Include="Finos.Fdc3.NewtonsoftJson" Version="2.0.0" />
-    <PackageVersion Include="Finos.Fdc3.AppDirectory" Version="2.0.0" />
+    <PackageVersion Include="Finos.Fdc3" Version="[2.0.0, 2.1)" />
+    <PackageVersion Include="Finos.Fdc3.NewtonsoftJson" Version="[2.0.0, 2.1)" />
+    <PackageVersion Include="Finos.Fdc3.AppDirectory" Version="[2.0.0, 2.1)" />
     <PackageVersion Include="FluentAssertions" Version="[7.0.0, 8.0.0)" />
     <PackageVersion Include="FluentAssertions.Json" Version="[6.1.0, 8.0)" />
     <PackageVersion Include="Google.Protobuf" Version="3.29.3" />

--- a/examples/fdc3-chart-and-grid/js-datagrid/package.json
+++ b/examples/fdc3-chart-and-grid/js-datagrid/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "17.3.12",
     "@angular/platform-browser-dynamic": "17.3.12",
     "@angular/router": "17.3.12",
-    "@finos/fdc3": "2.1.1",
+    "@finos/fdc3": "~2.0.3",
     "material-icons": "1.13.12",
     "rxjs": "7.8.1",
     "tslib": "2.7.0",

--- a/examples/fdc3-pricing-and-chat/js-chat/package.json
+++ b/examples/fdc3-pricing-and-chat/js-chat/package.json
@@ -12,7 +12,7 @@
     "start": "http-server -p 8082"
   },
   "dependencies": {
-    "@finos/fdc3": "^2.0.3",
+    "@finos/fdc3": "~2.0.3",
     "bootstrap": "^5.3.3",
     "jquery": "3.7.1",
     "rollup-plugin-import-css": "^3.5.0",

--- a/examples/fdc3-pricing-and-chat/js-pricing/package.json
+++ b/examples/fdc3-pricing-and-chat/js-pricing/package.json
@@ -12,7 +12,7 @@
     "start": "http-server -p 8081"
   },
   "dependencies": {
-    "@finos/fdc3": "^2.0.3",
+    "@finos/fdc3": "~2.0.3",
     "bootstrap": "^5.3.3",
     "jquery": "3.7.1",
     "tslib": "2.7.0"

--- a/examples/fdc3-trade-simulator/js-order-book/package.json
+++ b/examples/fdc3-trade-simulator/js-order-book/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "^17.3.0",
     "@angular/platform-browser-dynamic": "^17.3.0",
     "@angular/router": "^17.3.0",
-    "@finos/fdc3": "^2.0.0",
+    "@finos/fdc3": "~2.0.3",
     "material-icons": "^1.13.12",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "@angular/platform-browser": "17.3.12",
         "@angular/platform-browser-dynamic": "17.3.12",
         "@angular/router": "17.3.12",
-        "@finos/fdc3": "2.1.1",
+        "@finos/fdc3": "~2.0.3",
         "material-icons": "1.13.12",
         "rxjs": "7.8.1",
         "tslib": "2.7.0",
@@ -75,6 +75,12 @@
         "karma-jasmine-html-reporter": "2.1.0",
         "typescript": "5.4.5"
       }
+    },
+    "examples/fdc3-chart-and-grid/js-datagrid/node_modules/@finos/fdc3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@finos/fdc3/-/fdc3-2.0.3.tgz",
+      "integrity": "sha512-sq+iGbjU6yRl7xHhp62nB1tV4biFaHZgUAInzPTJvzXWl9xjZMmXvvbeZW6WGZaCSvjQhJPSrmWs+4z2c73T+g==",
+      "license": "Apache-2.0"
     },
     "examples/fdc3-chart-and-grid/js-datagrid/node_modules/tslib": {
       "version": "2.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
       "name": "@morgan-stanley/composeui-example-chat",
       "version": "0.1.0-alpha.1",
       "dependencies": {
-        "@finos/fdc3": "^2.0.3",
+        "@finos/fdc3": "~2.0.3",
         "bootstrap": "^5.3.3",
         "jquery": "3.7.1",
         "rollup-plugin-import-css": "^3.5.0",
@@ -104,6 +104,12 @@
         "rollup": "4.21.2"
       }
     },
+    "examples/fdc3-pricing-and-chat/js-chat/node_modules/@finos/fdc3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@finos/fdc3/-/fdc3-2.0.3.tgz",
+      "integrity": "sha512-sq+iGbjU6yRl7xHhp62nB1tV4biFaHZgUAInzPTJvzXWl9xjZMmXvvbeZW6WGZaCSvjQhJPSrmWs+4z2c73T+g==",
+      "license": "Apache-2.0"
+    },
     "examples/fdc3-pricing-and-chat/js-chat/node_modules/tslib": {
       "version": "2.7.0",
       "license": "0BSD"
@@ -112,7 +118,7 @@
       "name": "@morgan-stanley/composeui-example-pricing",
       "version": "0.1.0-alpha.1",
       "dependencies": {
-        "@finos/fdc3": "^2.0.3",
+        "@finos/fdc3": "~2.0.3",
         "bootstrap": "^5.3.3",
         "jquery": "3.7.1",
         "tslib": "2.7.0"
@@ -125,6 +131,12 @@
         "rollup": "4.21.2",
         "rollup-plugin-import-css": "^3.5.0"
       }
+    },
+    "examples/fdc3-pricing-and-chat/js-pricing/node_modules/@finos/fdc3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@finos/fdc3/-/fdc3-2.0.3.tgz",
+      "integrity": "sha512-sq+iGbjU6yRl7xHhp62nB1tV4biFaHZgUAInzPTJvzXWl9xjZMmXvvbeZW6WGZaCSvjQhJPSrmWs+4z2c73T+g==",
+      "license": "Apache-2.0"
     },
     "examples/fdc3-pricing-and-chat/js-pricing/node_modules/tslib": {
       "version": "2.7.0",
@@ -143,7 +155,7 @@
         "@angular/platform-browser": "^17.3.0",
         "@angular/platform-browser-dynamic": "^17.3.0",
         "@angular/router": "^17.3.0",
-        "@finos/fdc3": "^2.0.0",
+        "@finos/fdc3": "~2.0.3",
         "material-icons": "^1.13.12",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -162,6 +174,12 @@
         "karma-jasmine-html-reporter": "~2.1.0",
         "typescript": "~5.4.2"
       }
+    },
+    "examples/fdc3-trade-simulator/js-order-book/node_modules/@finos/fdc3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@finos/fdc3/-/fdc3-2.0.3.tgz",
+      "integrity": "sha512-sq+iGbjU6yRl7xHhp62nB1tV4biFaHZgUAInzPTJvzXWl9xjZMmXvvbeZW6WGZaCSvjQhJPSrmWs+4z2c73T+g==",
+      "license": "Apache-2.0"
     },
     "examples/fdc3-trade-simulator/js-order-book/node_modules/jasmine-core": {
       "version": "5.1.2",
@@ -17848,7 +17866,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@finos/fdc3": "^2.0.0",
+        "@finos/fdc3": "~2.0.3",
         "@morgan-stanley/composeui-messaging-client": "*",
         "@types/node": "^22.0.2",
         "jest-environment-jsdom": "^29.7.0",
@@ -17868,6 +17886,12 @@
         "tslib": "^2.4.0",
         "typescript": "^5.3.3"
       }
+    },
+    "src/fdc3/js/composeui-fdc3/node_modules/@finos/fdc3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@finos/fdc3/-/fdc3-2.0.3.tgz",
+      "integrity": "sha512-sq+iGbjU6yRl7xHhp62nB1tV4biFaHZgUAInzPTJvzXWl9xjZMmXvvbeZW6WGZaCSvjQhJPSrmWs+4z2c73T+g==",
+      "license": "Apache-2.0"
     },
     "src/messaging/js/composeui-messaging-client": {
       "name": "@morgan-stanley/composeui-messaging-client",

--- a/src/fdc3/js/composeui-fdc3/package.json
+++ b/src/fdc3/js/composeui-fdc3/package.json
@@ -17,7 +17,7 @@
   "author": "Morgan Stanley",
   "license": "Apache-2.0",
   "dependencies": {
-    "@finos/fdc3": "^2.0.0",
+    "@finos/fdc3": "~2.0.3",
     "@morgan-stanley/composeui-messaging-client": "*",
     "@types/node": "^22.0.2",
     "jest-environment-jsdom": "^29.7.0",


### PR DESCRIPTION
**Changes in this PR**

1. Conforming to FDC3 2.0 Standard
    * Grid example in fdc3-chart-and-grid has been downgraded to 2.0.3
    * The rest of the examples have been upgraded to the latest patch (2.0.3) while making sure that we only allow patch upgrades (~)

2. Preventing unintended upgrades via Dependabot
    * Ignoring Upgrades to 2.1 packages for both NPM and Nuget eco-systems