### PR TITLE
Add scope to site package name

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ms-gh-pages",
+  "name": "@morgan-stanley/ComposeUI-gh-pages",
   "version": "1.0.0",
   "private": true,
   "description": "ms-gh-pages",


### PR DESCRIPTION
Add package scope for consistency and best practice. While this is an app that can and never will be published, it is best to be consistent.