### PR TITLE
chore(github-actions/dependency-submission): Removing scheduled execution

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -2,8 +2,6 @@ name: Dependency Submission
 
 on:
   workflow_dispatch:
-  schedule: 
-    - cron: 0 19 * * * #7 PM ET
 
 permissions: 
   contents: read


### PR DESCRIPTION
*Changes in this PR*
- Removing cron config until the fixes are provided by the vendor so that dependabot is not trying to add unnecessary package references when raising a dependency upgrade PR triggered by a security alert.
- Note: it's still possibly to run the job manually when we want to test it.