### PR TITLE
feat(Shell): Add  FDC33 ChannelSelector

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,9 +29,12 @@
     </PropertyGroup>
 	
 	<PropertyGroup>
-		<TargetFrameworkVersion>net8.0</TargetFrameworkVersion>
+		<TargetFrameworkVersion>net8.0-windows10.0.17763.0</TargetFrameworkVersion>
 		<TargetFramework>$(TargetFrameworkVersion)</TargetFramework>
 		<LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
 	</PropertyGroup>
+    <PropertyGroup>
+        <WindowsSdkPackageVersion>10.0.17763.53</WindowsSdkPackageVersion> 
+    </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,12 +33,14 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="[8.0.1,9)" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="[8.0.2,9)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2957.106" />
-    <PackageVersion Include="Moq.Contrib.HttpClient" Version="1.4.0" />
+    <PackageVersion Include="MaterialDesignThemes" Version="5.1.0" />
+	  <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2957.106" />
+	  <PackageVersion Include="Moq.Contrib.HttpClient" Version="1.4.0" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
+    <PackageVersion Include="Prism.Core" Version="9.0.537" />
     <PackageVersion Include="Roslyn.System.IO.Abstractions.Analyzers" Version="12.2.19" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/examples/dotnet-diagnostics/DiagnosticsExample/DiagnosticsExample.csproj
+++ b/examples/dotnet-diagnostics/DiagnosticsExample/DiagnosticsExample.csproj
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and limitations 
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>$(TargetFrameworkVersion)-windows</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <UseWPF>true</UseWPF>
   </PropertyGroup>
 

--- a/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Abstractions/MorganStanley.ComposeUI.ProcessExplorer.Abstractions.csproj
+++ b/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Abstractions/MorganStanley.ComposeUI.ProcessExplorer.Abstractions.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+  <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Client/MorganStanley.ComposeUI.ProcessExplorer.Client.csproj
+++ b/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Client/MorganStanley.ComposeUI.ProcessExplorer.Client.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+  <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Core/MorganStanley.ComposeUI.ProcessExplorer.Core.csproj
+++ b/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.Core/MorganStanley.ComposeUI.ProcessExplorer.Core.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.GrpcWebServer/MorganStanley.ComposeUI.ProcessExplorer.GrpcWebServer.csproj
+++ b/prototypes/process-explorer/dotnet/src/MorganStanley.ComposeUI.ProcessExplorer.GrpcWebServer/MorganStanley.ComposeUI.ProcessExplorer.GrpcWebServer.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/prototypes/process-explorer/dotnet/test/MorganStanley.ComposeUI.ProcessExplorer.Client.Tests/MorganStanley.ComposeUI.ProcessExplorer.Client.Tests.csproj
+++ b/prototypes/process-explorer/dotnet/test/MorganStanley.ComposeUI.ProcessExplorer.Client.Tests/MorganStanley.ComposeUI.ProcessExplorer.Client.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+  <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/prototypes/process-explorer/dotnet/test/MorganStanley.ComposeUI.ProcessExplorer.Core.Tests/MorganStanley.ComposeUI.ProcessExplorer.Core.Tests.csproj
+++ b/prototypes/process-explorer/dotnet/test/MorganStanley.ComposeUI.ProcessExplorer.Core.Tests/MorganStanley.ComposeUI.ProcessExplorer.Core.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/prototypes/process-explorer/dotnet/test/MorganStanley.ComposeUI.TestConsoleApp/MorganStanley.ComposeUI.TestConsoleApp.csproj
+++ b/prototypes/process-explorer/dotnet/test/MorganStanley.ComposeUI.TestConsoleApp/MorganStanley.ComposeUI.TestConsoleApp.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/prototypes/process-explorer/dotnet/test/MorganStanley.ComposeUI.TestConsoleApp2/MorganStanley.ComposeUI.TestConsoleApp2.csproj
+++ b/prototypes/process-explorer/dotnet/test/MorganStanley.ComposeUI.TestConsoleApp2/MorganStanley.ComposeUI.TestConsoleApp2.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/fdc3/dotnet/AppDirectory/src/MorganStanley.ComposeUI.AppDirectory/MorganStanley.ComposeUI.AppDirectory.csproj
+++ b/src/fdc3/dotnet/AppDirectory/src/MorganStanley.ComposeUI.AppDirectory/MorganStanley.ComposeUI.AppDirectory.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
+	    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AssemblyName>MorganStanley.ComposeUI.Fdc3.AppDirectory</AssemblyName>
 		<RootNamespace>MorganStanley.ComposeUI.Fdc3.AppDirectory</RootNamespace>

--- a/src/fdc3/dotnet/AppDirectory/test/MorganStanley.ComposeUI.AppDirectory.Tests/MorganStanley.ComposeUI.AppDirectory.Tests.csproj
+++ b/src/fdc3/dotnet/AppDirectory/test/MorganStanley.ComposeUI.AppDirectory.Tests/MorganStanley.ComposeUI.AppDirectory.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+	    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<RootNamespace>MorganStanley.ComposeUI.Fdc3.AppDirectory</RootNamespace>
 		<IsPackable>false</IsPackable>

--- a/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/Contracts/ChannelSelectorRequest.cs
+++ b/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/Contracts/ChannelSelectorRequest.cs
@@ -12,27 +12,18 @@
  * and limitations under the License.
  */
 
-using MorganStanley.ComposeUI.Fdc3.DesktopAgent.Protocol;
 
 namespace MorganStanley.ComposeUI.Fdc3.DesktopAgent.Contracts;
 
-public sealed class JoinUserChannelResponse
+public class ChannelSelectorRequest
 {
     /// <summary>
-    /// Error while executing the JoinUserChannel call.
+    /// Uniques identifier of the channel.
     /// </summary>
-    public string? Error { get; set; }
+    public string ChannelId { get; set; }
 
     /// <summary>
-    /// Indicating if the request was successful.
+    /// Unique identifier of the app which sent the request.
     /// </summary>
-    public bool Success { get; set; }
-
-    /// <summary>
-    /// DisplayMetadata of the ChannelItem.
-    /// </summary>
-    public DisplayMetadata? DisplayMetadata { get; set; }
-
-    public static JoinUserChannelResponse Joined(DisplayMetadata? displayMetadata = null) => new() { Success = true, DisplayMetadata = displayMetadata };
-    public static JoinUserChannelResponse Failed(string error) => new() { Success = false, Error = error };
+    public string InstanceId { get; set; }
 }

--- a/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/Contracts/ChannelSelectorResponse.cs
+++ b/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/Contracts/ChannelSelectorResponse.cs
@@ -12,27 +12,26 @@
  * and limitations under the License.
  */
 
-using MorganStanley.ComposeUI.Fdc3.DesktopAgent.Protocol;
 
 namespace MorganStanley.ComposeUI.Fdc3.DesktopAgent.Contracts;
 
-public sealed class JoinUserChannelResponse
+/// <summary>
+/// Response from the service which provides the ResolverUI's functionality.
+/// </summary>
+public class ChannelSelectorResponse
 {
     /// <summary>
-    /// Error while executing the JoinUserChannel call.
+    /// Any error message that happened during execution, either from <see cref="ResolveError"/>.
     /// </summary>
+ 
     public string? Error { get; set; }
+
+    public string? InstanceId { get; set; }
 
     /// <summary>
     /// Indicating if the request was successful.
     /// </summary>
     public bool Success { get; set; }
 
-    /// <summary>
-    /// DisplayMetadata of the ChannelItem.
-    /// </summary>
-    public DisplayMetadata? DisplayMetadata { get; set; }
-
-    public static JoinUserChannelResponse Joined(DisplayMetadata? displayMetadata = null) => new() { Success = true, DisplayMetadata = displayMetadata };
-    public static JoinUserChannelResponse Failed(string error) => new() { Success = false, Error = error };
+    public string Color { get; set; }
 }

--- a/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/Contracts/JoinUserChannelRequest.cs
+++ b/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/Contracts/JoinUserChannelRequest.cs
@@ -14,7 +14,7 @@
 
 namespace MorganStanley.ComposeUI.Fdc3.DesktopAgent.Contracts;
 
-internal sealed class JoinUserChannelRequest
+public sealed class JoinUserChannelRequest
 {
     /// <summary>
     /// Uniques identifier of the channel.
@@ -25,4 +25,6 @@ internal sealed class JoinUserChannelRequest
     /// Unique identifier of the app which sent the request.
     /// </summary>
     public string InstanceId { get; set; }
+
+    public string Color { get; set; }
 }

--- a/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/Fdc3StartupAction.cs
+++ b/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/Fdc3StartupAction.cs
@@ -19,6 +19,7 @@ using ResourceReader = MorganStanley.ComposeUI.Utilities.ResourceReader;
 using Microsoft.Extensions.Options;
 using MorganStanley.ComposeUI.Fdc3.DesktopAgent.DependencyInjection;
 using System.Text;
+using System.Collections.ObjectModel;
 
 namespace MorganStanley.ComposeUI.Shell.Fdc3;
 
@@ -27,17 +28,20 @@ internal sealed class Fdc3StartupAction : IStartupAction
     private readonly IAppDirectory _appDirectory;
     private readonly IUserChannelSetReader _userChannelSetReader;
     private readonly Fdc3DesktopAgentOptions _options;
+    private readonly IChannelSelectorInstanceCommunicator _channelSelectorInstanceCommunicator;
     private readonly ILogger<Fdc3StartupAction> _logger;
 
     public Fdc3StartupAction(
         IAppDirectory appDirectory,
         IUserChannelSetReader userChannelSetReader,
         IOptions<Fdc3DesktopAgentOptions> options,
+        IChannelSelectorInstanceCommunicator channelSelectorInstanceCommunicator,
         ILogger<Fdc3StartupAction>? logger = null)
     {
         _appDirectory = appDirectory;
         _userChannelSetReader = userChannelSetReader;
         _options = options.Value;
+        _channelSelectorInstanceCommunicator = channelSelectorInstanceCommunicator;
         _logger = logger ?? NullLogger<Fdc3StartupAction>.Instance;
     }
 
@@ -49,18 +53,21 @@ internal sealed class Fdc3StartupAction : IStartupAction
             try
             {
                 var appId = (await _appDirectory.GetApp(startupContext.StartRequest.ModuleId)).AppId;
-                var userChannelSet = await _userChannelSetReader.GetUserChannelSet();
+                var userChannelSet = await _userChannelSetReader.GetUserChannelSet();                
+                var observableUserChannelCollection = new ObservableCollection<ComposeUI.Fdc3.DesktopAgent.Protocol.ChannelItem>(userChannelSet.Values);
+
                 var fdc3InstanceId = startupContext.StartRequest.Parameters.FirstOrDefault(parameter => parameter.Key == Fdc3StartupParameters.Fdc3InstanceId).Value ?? Guid.NewGuid().ToString();
                 
                 //TODO: decide if we want to join to a channel automatically on startup of an fdc3 module
                 //First we inject the channel id if we set as startup parameter eg.: when we open an app with `fdc3.open`
-                var channelId = startupContext.StartRequest.Parameters.FirstOrDefault(parameter => parameter.Key == Fdc3StartupParameters.Fdc3ChannelId).Value ?? _options.ChannelId ?? userChannelSet.FirstOrDefault().Key;
                 
+                var channelId = startupContext.StartRequest.Parameters.FirstOrDefault(parameter => parameter.Key == Fdc3StartupParameters.Fdc3ChannelId).Value ?? _options.ChannelId ?? userChannelSet.FirstOrDefault().Key;
+                var channelColor = userChannelSet[channelId].DisplayMetadata.Color;
                 var openedAppContextId =
                     startupContext.StartRequest.Parameters.FirstOrDefault(
                         x => x.Key == Fdc3StartupParameters.OpenedAppContextId).Value;
 
-                var fdc3StartupProperties = new Fdc3StartupProperties() { InstanceId = fdc3InstanceId, ChannelId = channelId, OpenedAppContextId = openedAppContextId };
+                var fdc3StartupProperties = new Fdc3StartupProperties() { InstanceId = fdc3InstanceId, ChannelId = channelId, OpenedAppContextId = openedAppContextId, UserChannelCollection = observableUserChannelCollection };
                 fdc3InstanceId = startupContext.GetOrAddProperty<Fdc3StartupProperties>(_ => fdc3StartupProperties).InstanceId;
 
                 var webProperties = startupContext.GetOrAddProperty<WebStartupProperties>();
@@ -101,6 +108,8 @@ internal sealed class Fdc3StartupAction : IStartupAction
                 stringBuilder.Append(ResourceReader.ReadResource(ResourceNames.Fdc3Bundle));
 
                 webProperties.ScriptProviders.Add(_ => new ValueTask<string>(stringBuilder.ToString()));
+                webProperties.InstanceId = fdc3InstanceId;
+                webProperties.ChannelColor = channelColor;
             }
             catch (AppNotFoundException exception)
             {

--- a/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/Fdc3StartupProperties.cs
+++ b/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/Fdc3StartupProperties.cs
@@ -12,9 +12,11 @@
  * and limitations under the License.
  */
 
+using System.Collections.ObjectModel;
+
 namespace MorganStanley.ComposeUI.Fdc3.DesktopAgent;
 
-internal class Fdc3StartupProperties
+public class Fdc3StartupProperties
 {
     /// <summary>
     /// Fdc3 DesktopAgent's specific identifier for the created application instance.
@@ -30,4 +32,6 @@ internal class Fdc3StartupProperties
     /// This implies that the opened app was started via using the fdc3.open() call. Thi id ensures that if the app opens and it's available on the object then the opened app can request the context and handle it when its context listener is being registered for the right context type.
     /// </summary>
     public string? OpenedAppContextId { get; set; }
+
+    public ObservableCollection<ComposeUI.Fdc3.DesktopAgent.Protocol.ChannelItem> UserChannelCollection { get; set; }
 }

--- a/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/Fdc3Topic.cs
+++ b/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/Fdc3Topic.cs
@@ -27,6 +27,7 @@ internal static class Fdc3Topic
     internal static string SendIntentResult => TopicRoot + "sendIntentResult";
     internal static string AddIntentListener => TopicRoot + "addIntentListener";
     internal static string ResolverUI => TopicRoot + "resolverUI";
+    internal static string ChangeChannel => TopicRoot + "changeChannel";
     internal static string CreatePrivateChannel => TopicRoot + "createPrivateChannel";
     internal static string CreateAppChannel => TopicRoot + "createAppChannel";
     internal static string GetUserChannels => TopicRoot + "getUserChannels";

--- a/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/IChannelSelector.cs
+++ b/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/IChannelSelector.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+using MorganStanley.ComposeUI.Fdc3.DesktopAgent.Contracts;
+
+namespace MorganStanley.ComposeUI.Fdc3.DesktopAgent
+{
+    public interface IChannelSelector
+    {
+       public Task SendChannelSelectorColorUpdateRequest(ChannelSelectorRequest req, string? color, CancellationToken cancellationToken = default);
+
+        public Task<ChannelSelectorResponse?> SendChannelSelectorRequest(string channelId, string instanceId, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/IChannelSelectorInstanceCommunicator.cs
+++ b/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/IChannelSelectorInstanceCommunicator.cs
@@ -1,0 +1,26 @@
+﻿/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+using MorganStanley.ComposeUI.Fdc3.DesktopAgent.Contracts;
+
+namespace MorganStanley.ComposeUI.Fdc3.DesktopAgent
+{
+    public delegate Task Fdc3ChannelSelectorColorupdateEventHandler(string color);
+    public interface IChannelSelectorInstanceCommunicator
+    {
+        public Task RegisterMessageRouterForInstance(string instanceId, Fdc3ChannelSelectorColorupdateEventHandler eventHandler, CancellationToken cancellationToken = default);
+
+        public void InvokeChannelSelectorRequest(ChannelSelectorRequest request, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/MorganStanley.ComposeUI.DesktopAgent.csproj
+++ b/src/fdc3/dotnet/DesktopAgent/src/MorganStanley.ComposeUI.DesktopAgent/MorganStanley.ComposeUI.DesktopAgent.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
+	      <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AssemblyName>MorganStanley.ComposeUI.Fdc3.DesktopAgent</AssemblyName>
 		<RootNamespace>MorganStanley.ComposeUI.Fdc3.DesktopAgent</RootNamespace>

--- a/src/fdc3/dotnet/DesktopAgent/test/MorganStanley.ComposeUI.DesktopAgent.Tests/MorganStanley.ComposeUI.DesktopAgent.Tests.csproj
+++ b/src/fdc3/dotnet/DesktopAgent/test/MorganStanley.ComposeUI.DesktopAgent.Tests/MorganStanley.ComposeUI.DesktopAgent.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <AssemblyName>MorganStanley.ComposeUI.Fdc3.DesktopAgent.Tests</AssemblyName>

--- a/src/fdc3/js/composeui-fdc3/src/ComposeUIDesktopAgent.ts
+++ b/src/fdc3/js/composeui-fdc3/src/ComposeUIDesktopAgent.ts
@@ -38,6 +38,7 @@ import { MetadataClient } from './infrastructure/MetadataClient';
 import { MessageRouterMetadataClient } from './infrastructure/MessageRouterMetadataClient';
 import { OpenClient } from "./infrastructure/OpenClient";
 import { MessageRouterOpenClient } from "./infrastructure/MessageRouterOpenClient";
+import { ChannelSelectorClient } from "./infrastructure/ChannelSelectorClient";
 
 export class ComposeUIDesktopAgent implements DesktopAgent {
     private appChannels: Channel[] = [];
@@ -52,6 +53,7 @@ export class ComposeUIDesktopAgent implements DesktopAgent {
     private openClient: OpenClient;
     private openedAppContext?: Context;
     private openedAppContextHandled: boolean = false;
+    private channelSelectorClient: ChannelSelectorClient;
 
     //TODO: we should enable passing multiple channelId to the ctor.
     constructor(messageRouterClient: MessageRouter, channelFactory?: ChannelFactory) {
@@ -64,6 +66,11 @@ export class ComposeUIDesktopAgent implements DesktopAgent {
         this.intentsClient = new MessageRouterIntentsClient(messageRouterClient, this.channelFactory);
         this.metadataClient = new MessageRouterMetadataClient(messageRouterClient, window.composeui.fdc3.config);
         this.openClient = new MessageRouterOpenClient(window.composeui.fdc3.config.instanceId!, messageRouterClient, window.composeui.fdc3.openAppIdentifier);
+        this.channelSelectorClient = new ChannelSelectorClient(messageRouterClient, window.composeui.fdc3.config.instanceId!, window.composeui.fdc3.channelId!);
+    }
+
+    public async selectChannel(){
+        await this.channelSelectorClient.subscribe();
     }
 
     public async open(app?: string | AppIdentifier, context?: Context): Promise<AppIdentifier> {
@@ -169,6 +176,7 @@ export class ComposeUIDesktopAgent implements DesktopAgent {
                     queueMicrotask(async () => await this.callHandlerOnChannelsCurrentContext(listener));
                 });
         }
+        this.channelSelectorClient.colorUpdate(channelId, channel.displayMetadata?.color);
     }
 
     public async getOrCreateChannel(channelId: string): Promise<Channel> {

--- a/src/fdc3/js/composeui-fdc3/src/index.ts
+++ b/src/fdc3/js/composeui-fdc3/src/index.ts
@@ -30,11 +30,12 @@ declare global {
     }
 }
 
-async function initialize(): Promise<void> {
+(async function initialize(): Promise<void> {
     //TODO: decide if we want to join to a channel by default.
     let channelId: string | undefined = window.composeui.fdc3.channelId;
     const openAppIdentifier: OpenAppIdentifier | undefined = window.composeui.fdc3.openAppIdentifier;
-    const fdc3 = new ComposeUIDesktopAgent(createMessageRouter());
+    const client = createMessageRouter();
+    const fdc3 = new ComposeUIDesktopAgent(client);
 
     if (channelId) {
         await fdc3.joinUserChannel(channelId)
@@ -61,6 +62,7 @@ async function initialize(): Promise<void> {
             window.dispatchEvent(new Event("fdc3Ready"));
         }
     }
-}
 
-initialize();
+    await fdc3.selectChannel();
+
+})();

--- a/src/fdc3/js/composeui-fdc3/src/infrastructure/ChannelSelectorClient.ts
+++ b/src/fdc3/js/composeui-fdc3/src/infrastructure/ChannelSelectorClient.ts
@@ -1,0 +1,44 @@
+﻿/* 
+ *  Morgan Stanley makes this available to you under the Apache License,
+ *  Version 2.0 (the "License"). You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0.
+ *  See the NOTICE file distributed with this work for additional information
+ *  regarding copyright ownership. Unless required by applicable law or agreed
+ *  to in writing, software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ *  or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+import { MessageRouter, TopicMessage } from "@morgan-stanley/composeui-messaging-client";
+import { ChannelSelectorResponse } from "./messages/ChannelSelectorResponse";
+import { ChannelSelectorRequest } from "./messages/ChannelSelectorRequest"
+
+export class ChannelSelectorClient {
+    constructor(private readonly messageRouterClient: MessageRouter,  private readonly instanceId: string, private readonly channelId: string){
+    
+    }
+
+    public async subscribe() : Promise<string>{
+        await this.messageRouterClient.connect();
+        await this.messageRouterClient.subscribe("ComposeUI/fdc3/v2.0/changeChannel", (topicMessage: TopicMessage) => {
+            const payload = <ChannelSelectorResponse>JSON.parse(topicMessage.payload!); //todo check parsing as lowercase doesn't work
+            
+            if(payload.instanceId === this.instanceId)
+            {
+                window.fdc3.joinUserChannel(payload.channelId);
+            }
+        });
+        return this.channelId!;
+    }
+
+    public async colorUpdate(channelId: string, channelColor: string | undefined ) : Promise<void | undefined>{       
+        const message = JSON.stringify(new ChannelSelectorRequest(
+            channelId,
+            this.instanceId,
+            channelColor
+       ));
+
+       await this.messageRouterClient.publish(`ComposeUI/fdc3/v2.0/channelSelectorColor-${this.instanceId}`, message);
+    }
+}

--- a/src/fdc3/js/composeui-fdc3/src/infrastructure/messages/ChannelSelectorRequest.ts
+++ b/src/fdc3/js/composeui-fdc3/src/infrastructure/messages/ChannelSelectorRequest.ts
@@ -1,0 +1,19 @@
+/* 
+ *  Morgan Stanley makes this available to you under the Apache License,
+ *  Version 2.0 (the "License"). You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0.
+ *  See the NOTICE file distributed with this work for additional information
+ *  regarding copyright ownership. Unless required by applicable law or agreed
+ *  to in writing, software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ *  or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+export class ChannelSelectorRequest { 
+    constructor(
+        public readonly instanceId: string,
+        public readonly channelId: string,
+        public readonly color: string | undefined
+    ){}
+}

--- a/src/fdc3/js/composeui-fdc3/src/infrastructure/messages/ChannelSelectorResponse.ts
+++ b/src/fdc3/js/composeui-fdc3/src/infrastructure/messages/ChannelSelectorResponse.ts
@@ -1,0 +1,16 @@
+/* 
+ *  Morgan Stanley makes this available to you under the Apache License,
+ *  Version 2.0 (the "License"). You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0.
+ *  See the NOTICE file distributed with this work for additional information
+ *  regarding copyright ownership. Unless required by applicable law or agreed
+ *  to in writing, software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ *  or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ */
+
+export interface ChannelSelectorResponse {
+    instanceId: string;
+    channelId: string;
+}

--- a/src/layout-persistence/dotnet/src/MorganStanley.ComposeUI.LayoutPersistence/MorganStanley.ComposeUI.LayoutPersistence.csproj
+++ b/src/layout-persistence/dotnet/src/MorganStanley.ComposeUI.LayoutPersistence/MorganStanley.ComposeUI.LayoutPersistence.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/src/layout-persistence/dotnet/tests/MorganStanley.ComposeUI.LayoutPersistence.Tests/MorganStanley.ComposeUI.LayoutPersistence.Tests.csproj
+++ b/src/layout-persistence/dotnet/tests/MorganStanley.ComposeUI.LayoutPersistence.Tests/MorganStanley.ComposeUI.LayoutPersistence.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
 
     <IsPackable>false</IsPackable>

--- a/src/messaging/dotnet/examples/TestServer/TestServer.csproj
+++ b/src/messaging/dotnet/examples/TestServer/TestServer.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+	    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 		<OutputType>Exe</OutputType>
 		<ImplicitUsings>enable</ImplicitUsings>
 	</PropertyGroup>

--- a/src/messaging/dotnet/src/Abstractions/MorganStanley.ComposeUI.Messaging.Abstractions.csproj
+++ b/src/messaging/dotnet/src/Abstractions/MorganStanley.ComposeUI.Messaging.Abstractions.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/src/messaging/dotnet/src/Client/MorganStanley.ComposeUI.Messaging.Client.csproj
+++ b/src/messaging/dotnet/src/Client/MorganStanley.ComposeUI.Messaging.Client.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+	    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<RootNamespace>MorganStanley.ComposeUI.Messaging</RootNamespace>
 		<Description>.NET Client for ComposeUI's Message Router. More Details: http://opensource.morganstanley.com/ComposeUI/</Description>

--- a/src/messaging/dotnet/src/Core/MorganStanley.ComposeUI.Messaging.Core.csproj
+++ b/src/messaging/dotnet/src/Core/MorganStanley.ComposeUI.Messaging.Core.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+	    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/messaging/dotnet/src/Host/MorganStanley.ComposeUI.Messaging.Host.csproj
+++ b/src/messaging/dotnet/src/Host/MorganStanley.ComposeUI.Messaging.Host.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+	    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<RootNamespace>MorganStanley.ComposeUI.Messaging</RootNamespace>

--- a/src/messaging/dotnet/src/Server/MorganStanley.ComposeUI.Messaging.Server.csproj
+++ b/src/messaging/dotnet/src/Server/MorganStanley.ComposeUI.Messaging.Server.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+	    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<RootNamespace>MorganStanley.ComposeUI.Messaging</RootNamespace>
 		<Description>.NET Server Package for ComposeUI's Message Router. More Details: http://opensource.morganstanley.com/ComposeUI/</Description>

--- a/src/messaging/dotnet/test/Client.Tests/MorganStanley.ComposeUI.Messaging.Client.Tests.csproj
+++ b/src/messaging/dotnet/test/Client.Tests/MorganStanley.ComposeUI.Messaging.Client.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 	  <IsPackable>false</IsPackable>
 	  <RootNamespace>MorganStanley.ComposeUI.Messaging</RootNamespace>
   </PropertyGroup>

--- a/src/messaging/dotnet/test/Core.Tests/MorganStanley.ComposeUI.Messaging.Core.Tests.csproj
+++ b/src/messaging/dotnet/test/Core.Tests/MorganStanley.ComposeUI.Messaging.Core.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+	    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 		<RootNamespace>MorganStanley.ComposeUI.Messaging</RootNamespace>
 	</PropertyGroup>

--- a/src/messaging/dotnet/test/Host.Tests/MorganStanley.ComposeUI.Messaging.Host.Tests.csproj
+++ b/src/messaging/dotnet/test/Host.Tests/MorganStanley.ComposeUI.Messaging.Host.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+	    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 		<RootNamespace>MorganStanley.ComposeUI.Messaging</RootNamespace>
 	</PropertyGroup>

--- a/src/messaging/dotnet/test/IntegrationTests/MorganStanley.ComposeUI.Messaging.IntegrationTests.csproj
+++ b/src/messaging/dotnet/test/IntegrationTests/MorganStanley.ComposeUI.Messaging.IntegrationTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+	    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 		<RootNamespace>MorganStanley.ComposeUI.Messaging</RootNamespace>
 	</PropertyGroup>

--- a/src/messaging/dotnet/test/Server.Tests/MorganStanley.ComposeUI.Messaging.Server.Tests.csproj
+++ b/src/messaging/dotnet/test/Server.Tests/MorganStanley.ComposeUI.Messaging.Server.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+	    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 		<RootNamespace>MorganStanley.ComposeUI.Messaging</RootNamespace>
 	</PropertyGroup>

--- a/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader.Abstractions/MorganStanley.ComposeUI.ModuleLoader.Abstractions.csproj
+++ b/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader.Abstractions/MorganStanley.ComposeUI.ModuleLoader.Abstractions.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>MorganStanley.ComposeUI.ModuleLoader</RootNamespace>
   </PropertyGroup>

--- a/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader.Abstractions/WebStartupProperties.cs
+++ b/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader.Abstractions/WebStartupProperties.cs
@@ -21,6 +21,10 @@ public sealed class WebStartupProperties
     public Uri Url { get; set; } = ModuleLoaderConstants.DefaultUri;
     public Uri? IconUrl { get; set; }
     public List<WebModuleScriptProvider> ScriptProviders { get; } = new();
+
+    public string? InstanceId { get; set; }
+    public string? ChannelColor { get; set; }
+    public object Fdc3ChannelSelectorControl { get; set; }
 }
 
 public delegate ValueTask<string> WebModuleScriptProvider(IModuleInstance moduleInstance);

--- a/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader/MorganStanley.ComposeUI.ModuleLoader.csproj
+++ b/src/module-loader/dotnet/src/MorganStanley.ComposeUI.ModuleLoader/MorganStanley.ComposeUI.ModuleLoader.csproj
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and limitations 
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Abstractions.Tests/MorganStanley.ComposeUI.ModuleLoader.Abstractions.Tests.csproj
+++ b/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Abstractions.Tests/MorganStanley.ComposeUI.ModuleLoader.Abstractions.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+	    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<IsPackable>false</IsPackable>

--- a/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/MorganStanley.ComposeUI.ModuleLoader.Tests.csproj
+++ b/src/module-loader/dotnet/tests/MorganStanley.ComposeUI.ModuleLoader.Tests/MorganStanley.ComposeUI.ModuleLoader.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+	    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<IsPackable>false</IsPackable>

--- a/src/module-loader/dotnet/tests/NativeRunnerTestApp/NativeRunnerTestApp.csproj
+++ b/src/module-loader/dotnet/tests/NativeRunnerTestApp/NativeRunnerTestApp.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/shared/dotnet/tests/MorganStanley.ComposeUI.Utilities.Tests/MorganStanley.ComposeUI.Utilities.Tests.csproj
+++ b/src/shared/dotnet/tests/MorganStanley.ComposeUI.Utilities.Tests/MorganStanley.ComposeUI.Utilities.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+	    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>

--- a/src/shared/dotnet/tests/TestUtils/MorganStanley.ComposeUI.Testing/MorganStanley.ComposeUI.Testing.csproj
+++ b/src/shared/dotnet/tests/TestUtils/MorganStanley.ComposeUI.Testing/MorganStanley.ComposeUI.Testing.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/src/shell/dotnet/Shell/App.xaml
+++ b/src/shell/dotnet/Shell/App.xaml
@@ -11,8 +11,16 @@ See the License for the specific language governing permissions and limitations 
 <Application x:Class="MorganStanley.ComposeUI.Shell.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
->
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+ >
     <Application.Resources>
-         
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <materialDesign:BundledTheme BaseTheme="Light" PrimaryColor="DeepPurple" SecondaryColor="Lime" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign2.Defaults.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/Generic.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ObsoleteBrushes.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/shell/dotnet/Shell/App.xaml.cs
+++ b/src/shell/dotnet/Shell/App.xaml.cs
@@ -26,11 +26,13 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using MorganStanley.ComposeUI.Fdc3.AppDirectory;
+using MorganStanley.ComposeUI.Fdc3.DesktopAgent;
 using MorganStanley.ComposeUI.Fdc3.DesktopAgent.DependencyInjection;
 using MorganStanley.ComposeUI.Messaging;
 using MorganStanley.ComposeUI.ModuleLoader;
 using MorganStanley.ComposeUI.Shell.Abstractions;
 using MorganStanley.ComposeUI.Shell.Fdc3;
+using MorganStanley.ComposeUI.Shell.Fdc3.ChannelSelector;
 using MorganStanley.ComposeUI.Shell.Fdc3.ResolverUI;
 using MorganStanley.ComposeUI.Shell.Messaging;
 using MorganStanley.ComposeUI.Shell.Modules;
@@ -200,13 +202,16 @@ public partial class App : Application
                 services.AddFdc3DesktopAgent(desktopAgent => desktopAgent.UseMessageRouter());
                 services.AddFdc3AppDirectory();
                 services.AddSingleton<Fdc3ResolverUIWindow>();
-                services.AddSingleton<IResolverUIProjector>(p => p.GetRequiredService<Fdc3ResolverUIWindow>());
-                services.AddHostedService<ResolverUIService>();
+                services.AddSingleton<IResolverUIProjector>(p => p.GetRequiredService<Fdc3ResolverUIWindow>());                
+                services.AddTransient<IChannelSelectorInstanceCommunicator, ChannelSelectorInstanceCommunicator>();
+                services.AddTransient<IChannelSelector, Fdc3ChannelSelectorViewModel>();
+                services.AddHostedService<ResolverUIService>();              
                 services.Configure<Fdc3Options>(fdc3ConfigurationSection);
                 services.Configure<Fdc3DesktopAgentOptions>(
                     fdc3ConfigurationSection.GetSection(nameof(fdc3Options.DesktopAgent)));
                 services.Configure<AppDirectoryOptions>(
                     fdc3ConfigurationSection.GetSection(nameof(fdc3Options.AppDirectory)));
+                services.AddTransient<IStartupAction, Fdc3ChannelSelectorStartupAction>();
             }
         }
     }

--- a/src/shell/dotnet/Shell/Fdc3/ChannelSelector/ChannelSelectorInstanceCommunicator.cs
+++ b/src/shell/dotnet/Shell/Fdc3/ChannelSelector/ChannelSelectorInstanceCommunicator.cs
@@ -1,0 +1,99 @@
+﻿/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+using System.Collections.Generic;
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using MorganStanley.ComposeUI.Fdc3.DesktopAgent;
+using MorganStanley.ComposeUI.Fdc3.DesktopAgent.Contracts;
+using MorganStanley.ComposeUI.Messaging;
+using MorganStanley.ComposeUI.Messaging.Abstractions;
+using System.Windows;
+
+namespace MorganStanley.ComposeUI.Shell.Fdc3.ChannelSelector
+{
+    internal class ChannelSelectorInstanceCommunicator : IChannelSelectorInstanceCommunicator
+    {
+        private readonly ILogger<ChannelSelectorInstanceCommunicator> _logger;
+        private readonly IMessageRouter _messageRouter;
+        private readonly object _disposeLock = new();
+        private readonly List<Func<ValueTask>> _disposeTask = new();
+        private readonly JsonSerializerOptions _jsonSerializerOptions = new(JsonSerializerDefaults.Web);
+
+        IChannelSelectorInstanceCommunicator _channelSelectorComm;
+
+        public ChannelSelectorInstanceCommunicator(IMessageRouter messageRouter) {
+            _messageRouter = messageRouter;
+        }
+         public async void InvokeChannelSelectorRequest(ChannelSelectorRequest request, CancellationToken cancellationToken = default)
+         {
+             await _messageRouter.PublishAsync(
+                 "ComposeUI/fdc3/v2.0/changeChannel",
+                 MessageBuffer.Factory.CreateJson(request, _jsonSerializerOptions),
+                 cancellationToken: cancellationToken
+             );
+         }
+        
+         public async Task RegisterMessageRouterForInstance(string instanceId, Fdc3ChannelSelectorColorupdateEventHandler eventHandler, CancellationToken cancellationToken = default)
+         {
+             await _messageRouter.RegisterServiceAsync(
+             $"ComposeUI/fdc3/v2.0/channelSelector-{instanceId}",
+             async (endpoint, payload, context) =>
+             {
+                 var request = payload?.ReadJson<ChannelSelectorRequest>(_jsonSerializerOptions);
+                 if (request == null)
+                 {
+                     return null;
+                 }
+                 
+
+                 return null;
+             },
+             cancellationToken: cancellationToken);
+
+            
+            var subscription = await _messageRouter.SubscribeAsync($"ComposeUI/fdc3/v2.0/channelSelectorColor-{instanceId}", 
+                
+                async (payloadBuffer) => {
+                    var request = payloadBuffer?.ReadJson<JoinUserChannelRequest>(_jsonSerializerOptions);
+                    if (request == null)
+                    {
+                        return;
+                    }
+
+                    await Application.Current.Dispatcher.InvokeAsync(async () =>
+                    {
+                        eventHandler(request.Color);
+                    });
+                },
+                cancellationToken: default);
+
+             lock (_disposeLock)
+             {
+                 _disposeTask.Add(
+                     async () =>
+                     {
+                         if (_messageRouter != null)
+                         {
+                             await _messageRouter.UnregisterServiceAsync($"ComposeUI/fdc3/v2.0/channelSelector-{instanceId}");
+                             await _messageRouter.DisposeAsync();
+                         }
+                     });
+             }
+         }
+    }
+}

--- a/src/shell/dotnet/Shell/Fdc3/ChannelSelector/Fdc3ChannelSelectorControl.xaml
+++ b/src/shell/dotnet/Shell/Fdc3/ChannelSelector/Fdc3ChannelSelectorControl.xaml
@@ -1,0 +1,65 @@
+﻿ <!--
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ -->
+    
+<UserControl x:Class="MorganStanley.ComposeUI.Shell.Fdc3.ChannelSelector.Fdc3ChannelSelectorControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:MorganStanley.ComposeUI.Shell.Fdc3.ChannelSelector"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes" 
+             d:DataContext="{d:DesignInstance Type=local:Fdc3ChannelSelectorViewModel}"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <materialDesign:PopupBox
+            Panel.ZIndex="100"
+            x:Name="ChannelSelector"
+            Grid.Row="3"
+            VerticalAlignment="Bottom"
+            BorderBrush="{Binding CurrentChannelColor, Mode=TwoWay}"
+            BorderThickness="8.0"
+            HorizontalAlignment="Left"
+            IsEnabled="{Binding DataContext.ControlsEnabled, RelativeSource={RelativeSource FindAncestor, AncestorType=Window}}"
+            Style="{StaticResource MaterialDesignMultiFloatingActionSecondaryPopupBox}"
+            ToggleCheckedContentCommand="{Binding FloatingActionDemoCommand}"
+            ToggleCheckedContentCommandParameter="wowsers"
+            ToolTip="PopupBox, Style MaterialDesignMultiFloatingActionSecondaryPopupBox">
+            
+            <StackPanel x:Name="ChannelButtons">
+                <ItemsControl 
+                    ItemsSource="{Binding UserChannelCollection}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            
+                            <Button
+                                Content= "{Binding DisplayMetadata.Glyph}"
+                                ToolTip="{Binding DisplayMetadata.Name}" 
+                                Background="{Binding DisplayMetadata.Color}"
+                                Click="Button_Click"
+                            />
+
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel Orientation="Vertical" />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                </ItemsControl>
+            </StackPanel>
+        </materialDesign:PopupBox>
+    </Grid>
+</UserControl>

--- a/src/shell/dotnet/Shell/Fdc3/ChannelSelector/Fdc3ChannelSelectorControl.xaml.cs
+++ b/src/shell/dotnet/Shell/Fdc3/ChannelSelector/Fdc3ChannelSelectorControl.xaml.cs
@@ -1,0 +1,64 @@
+﻿/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using MorganStanley.ComposeUI.Fdc3.DesktopAgent;
+
+namespace MorganStanley.ComposeUI.Shell.Fdc3.ChannelSelector
+{
+    /// <summary>
+    /// Interaction logic for Fdc3ChannelSelectorControl.xaml
+    /// </summary>
+    public partial class Fdc3ChannelSelectorControl : UserControl
+    {
+        private readonly Fdc3ChannelSelectorViewModel? _viewModel;
+        private string _instanceId;
+        private ObservableCollection<ComposeUI.Fdc3.DesktopAgent.Protocol.ChannelItem> _userChannelCollection;
+
+        public Fdc3ChannelSelectorControl(IChannelSelectorInstanceCommunicator channelSelectorCommunicator, string color, string instanceId, ObservableCollection<ComposeUI.Fdc3.DesktopAgent.Protocol.ChannelItem> userChannelCollection)
+        {
+            _viewModel = new Fdc3ChannelSelectorViewModel(channelSelectorCommunicator, userChannelCollection, instanceId, color);
+            _instanceId = instanceId;
+            _userChannelCollection = userChannelCollection;
+            DataContext = _viewModel;
+
+            InitializeComponent();
+        }
+
+        private async void Button_Click(object sender, RoutedEventArgs e)
+        {
+            Button btn = (Button) sender;
+            var channelNumber = (string)btn.Content;
+            var color = btn.Background;
+            
+            await Task.Run(() =>
+            {
+                var channelId = _userChannelCollection.FirstOrDefault(x => x.DisplayMetadata.Glyph == channelNumber).Id;
+
+                _viewModel.SendChannelSelectorRequest(channelId, _instanceId);
+            });
+            
+            ChannelSelector.BorderBrush = color;
+        }
+
+        public async Task ColorUpdate(string color) 
+        {
+            await _viewModel.UpdateChannelSelectorColor(color);   
+        }
+    }
+}

--- a/src/shell/dotnet/Shell/Fdc3/ChannelSelector/Fdc3ChannelSelectorStartupAction.cs
+++ b/src/shell/dotnet/Shell/Fdc3/ChannelSelector/Fdc3ChannelSelectorStartupAction.cs
@@ -1,0 +1,63 @@
+﻿/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+using System;
+using System.Threading.Tasks;
+using MorganStanley.ComposeUI.Fdc3.DesktopAgent;
+using MorganStanley.ComposeUI.Messaging;
+using MorganStanley.ComposeUI.ModuleLoader;
+
+namespace MorganStanley.ComposeUI.Shell.Fdc3.ChannelSelector
+{
+    internal class Fdc3ChannelSelectorStartupAction : IStartupAction
+    {
+        private Fdc3ChannelSelectorControl _fdc3ChannelSelectorControl;
+        private IMessageRouter _messageRouter;
+        private string _color;
+        private string _instanceId;
+        private readonly IChannelSelectorInstanceCommunicator _channelSelectorInstanceCommunicator;
+
+
+        public Fdc3ChannelSelectorStartupAction( IMessageRouter messageRouter)
+        {
+           _messageRouter = messageRouter;
+           _channelSelectorInstanceCommunicator = new ChannelSelectorInstanceCommunicator(_messageRouter);
+        }
+
+        public async Task InvokeAsync(StartupContext startupContext, Func<Task> next)
+        {
+            if (startupContext.ModuleInstance.Manifest.ModuleType == ModuleType.Web)
+            {
+                var webStartupProperties = startupContext.GetOrAddProperty<WebStartupProperties>();
+                var color = webStartupProperties.ChannelColor;
+                var instanceId = webStartupProperties.InstanceId;
+
+                var fdc3StartupProperties = startupContext.GetOrAddProperty<Fdc3StartupProperties>();
+                var userChannelCollection = fdc3StartupProperties.UserChannelCollection;
+
+                _fdc3ChannelSelectorControl = new Fdc3ChannelSelectorControl(_channelSelectorInstanceCommunicator, color, instanceId, userChannelCollection);
+
+                await Task.Run(async () =>
+                {
+                    await _channelSelectorInstanceCommunicator.RegisterMessageRouterForInstance(instanceId, _fdc3ChannelSelectorControl.ColorUpdate);
+                });
+
+
+                webStartupProperties.Fdc3ChannelSelectorControl = _fdc3ChannelSelectorControl;
+            }
+
+            await (next.Invoke());
+        }
+    }
+}

--- a/src/shell/dotnet/Shell/Fdc3/ChannelSelector/Fdc3ChannelSelectorViewModel.cs
+++ b/src/shell/dotnet/Shell/Fdc3/ChannelSelector/Fdc3ChannelSelectorViewModel.cs
@@ -1,0 +1,137 @@
+﻿/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Finos.Fdc3;
+using MorganStanley.ComposeUI.Fdc3.DesktopAgent;
+using System.Windows.Media;
+using System.ComponentModel;
+using System.Threading;
+using MorganStanley.ComposeUI.Fdc3.DesktopAgent.Contracts;
+using Microsoft.Extensions.Logging;
+using System.Collections.ObjectModel;
+
+
+namespace MorganStanley.ComposeUI.Shell.Fdc3.ChannelSelector
+{
+    public class Fdc3ChannelSelectorViewModel : INotifyPropertyChanged, IChannelSelector
+    {
+        public IChannelSelectorInstanceCommunicator ChannelSelectorInstanceCommunicator;
+        public event PropertyChangedEventHandler? PropertyChanged;
+        public ObservableCollection<ComposeUI.Fdc3.DesktopAgent.Protocol.ChannelItem> UserChannelCollection { get; } = new();
+        private readonly ILogger<ChannelSelectorInstanceCommunicator> _logger;
+        private readonly object _disposeLock = new();
+        private readonly List<Func<ValueTask>> _disposeTask = new();
+
+        public Fdc3ChannelSelectorViewModel(IChannelSelectorInstanceCommunicator channelSelectorInstanceCommunicator, ObservableCollection<ComposeUI.Fdc3.DesktopAgent.Protocol.ChannelItem> userChannelCollection, string instanceId = "", string color = "Gray" )
+        {
+            ChannelSelectorInstanceCommunicator = channelSelectorInstanceCommunicator;
+            UserChannelCollection = userChannelCollection;
+
+            SetCurrentColor(_currentChannelColor);
+
+            if (color != null)
+            {
+                var brushColor = GetBrushForColor(color);
+                SetCurrentColor(brushColor);
+            }
+        }
+
+        private Brush GetBrushForColor(string color)
+        {
+            var myColor = (Color) ColorConverter.ConvertFromString(color);
+            SolidColorBrush brush = new SolidColorBrush(myColor);
+
+            return brush;
+        }
+
+        private void SetCurrentColor(Brush color)
+        {
+            CurrentChannelColor = color;
+            OnPropertyChanged(nameof(CurrentChannelColor));
+        }
+
+        private void SetCurrentChannelColor()
+        {
+            CurrentChannelColor = _currentChannelColor;
+            SetCurrentColor(_currentChannelColor);
+        }
+
+        private Brush _currentChannelColor = new SolidColorBrush(Colors.Gray);
+
+         public Brush CurrentChannelColor
+         {
+             get => _currentChannelColor;
+             set
+             {
+                 _currentChannelColor = value;
+                 OnPropertyChanged(nameof(CurrentChannelColor));
+             }
+         }
+
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        public Task UpdateChannelSelectorColor(string color)
+        {
+           var brushColor = GetBrushForColor(color);
+
+            SetCurrentColor(brushColor); 
+
+            return Task.CompletedTask;
+        }
+
+        public async Task SendChannelSelectorColorUpdateRequest(ChannelSelectorRequest req, string? color, CancellationToken cancellationToken = default)
+        {
+            await UpdateChannelSelectorColor(color);
+        }
+
+        public async Task<ChannelSelectorResponse?> SendChannelSelectorRequest(string channelId, string instanceId, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                return await SendChannelSelectorRequestCore(channelId, instanceId, cancellationToken);
+            }
+            catch (TimeoutException ex)
+            {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug(ex, "MessageRouter didn't receive response from the Channel Selector.");
+                }
+
+                return new ChannelSelectorResponse()
+                {
+                    Error = ResolveError.ResolverTimeout
+                };
+            }
+        }
+
+        private async Task<ChannelSelectorResponse?> SendChannelSelectorRequestCore(string channelId, string instanceId, CancellationToken cancellationToken = default)
+        {
+            var request = new ChannelSelectorRequest
+            {
+                ChannelId = channelId,
+                InstanceId = instanceId
+            };
+
+            ChannelSelectorInstanceCommunicator.InvokeChannelSelectorRequest(request, cancellationToken);
+
+            return null;
+        }
+    }
+}

--- a/src/shell/dotnet/Shell/MainWindow.xaml
+++ b/src/shell/dotnet/Shell/MainWindow.xaml
@@ -21,7 +21,8 @@ See the License for the specific language governing permissions and limitations 
               Width="600"
               Background="{DynamicResource {x:Static SystemColors.AppWorkspaceBrushKey}}"
               WindowStartupLocation="CenterScreen"
-              Initialized="RibbonWindow_Initialized">
+              Initialized="RibbonWindow_Initialized"
+              Style="{StaticResource MaterialDesignWindow}">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -59,7 +60,11 @@ See the License for the specific language governing permissions and limitations 
                                    ShowFloatingWindowsInTaskbar="True"
                                    LayoutMode="FillContainer">
                 <igDock:XamDockManager.Panes>
-                    <igDock:SplitPane x:Name="_verticalSplit" SplitterOrientation="Vertical" igDock:XamDockManager.InitialLocation="DockedLeft" />
+                    <igDock:SplitPane x:Name="_verticalSplit" 
+                                      SplitterOrientation="Vertical" 
+                                      igDock:XamDockManager.InitialLocation="DockedLeft">
+                        
+                    </igDock:SplitPane>
                 </igDock:XamDockManager.Panes>
             </igDock:XamDockManager>
         </Grid>

--- a/src/shell/dotnet/Shell/Properties/launchSettings.json
+++ b/src/shell/dotnet/Shell/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "profiles": {
     "Chart and grid": {
       "commandName": "Project",
@@ -6,7 +6,7 @@
     },
     "Shell": {
       "commandName": "Project",
-      "commandLineArgs": "--ModuleCatalog:CatalogUrl \"file:///$(ProjectDir)..\\examples\\module-catalog.json\" --FDC3:AppDirectory:Source $(ComposeUIRepositoryRoot)/examples/fdc3-appdirectory/apps.json"
+      "commandLineArgs": "--ModuleCatalog:CatalogUrl \"file:///$(ProjectDir)..\\examples\\module-catalog.json\" --FDC3:AppDirectory:Source $(ComposeUIRepositoryRoot)/examples/fdc3-appdirectory/apps-with-intents.json"
     },
     "FINOS FDC3": {
       "commandName": "Project",

--- a/src/shell/dotnet/Shell/Shell.csproj
+++ b/src/shell/dotnet/Shell/Shell.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>$(TargetFrameworkVersion)-windows</TargetFramework>
+		<TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
 		<UseWPF>true</UseWPF>
 		<EnableDefaultPageItems>false</EnableDefaultPageItems>
 		<AssemblyName>MorganStanley.ComposeUI.Shell</AssemblyName>

--- a/src/shell/dotnet/Shell/Shell.csproj
+++ b/src/shell/dotnet/Shell/Shell.csproj
@@ -10,6 +10,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<None Remove="Fdc3\ChannelSelector\Fdc3ChannelSelectorControl.xaml" />
 		<None Remove="Fdc3\ResolverUI\ResolverUIIntent.xaml" />
 		<None Remove="MainWindow.xaml" />
 		<None Remove="WebContent.xaml" />
@@ -17,9 +18,11 @@
 	
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" />
+		<PackageReference Include="MaterialDesignThemes" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" />
 		<PackageReference Include="Microsoft.Extensions.Http" />
 		<PackageReference Include="Microsoft.Web.WebView2" />
+		<PackageReference Include="Prism.Core" />
 		<PackageReference Include="System.Drawing.Common" />
 		<PackageReference Include="Infragistics.WPF.DockManager.Trial" />
 		<PackageReference Include="Infragistics.WPF.Trial" />
@@ -27,6 +30,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<Page Include="Fdc3\ChannelSelector\Fdc3ChannelSelectorControl.xaml" />
 		<Page Include="Fdc3\ResolverUI\ResolverUIIntent.xaml">
 		  <Generator>MSBuild:Compile</Generator>
 		</Page>

--- a/src/shell/dotnet/Shell/WebContent.xaml
+++ b/src/shell/dotnet/Shell/WebContent.xaml
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 ********************************************************************************************************
 Morgan Stanley makes this available to you under the Apache License, Version 2.0 (the "License").
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
@@ -15,9 +15,14 @@ See the License for the specific language governing permissions and limitations 
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
-        xmlns:local="clr-namespace:MorganStanley.ComposeUI.Shell"
-        mc:Ignorable="d">
+        xmlns:local="clr-namespace:MorganStanley.ComposeUI.Shell" 
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes" 
+        xmlns:channelselector="clr-namespace:MorganStanley.ComposeUI.Shell.Fdc3.ChannelSelector"
+        mc:Ignorable="d"
+>
     <ContentPresenter.Content>
-         <wv2:WebView2 Name = "WebView" Source = "" />
+        <Grid x:Name="LayoutRoot">
+            <wv2:WebView2CompositionControl Name = "WebView" Source = "" Grid.Row="1"/>
+        </Grid>
     </ContentPresenter.Content>
 </ContentPresenter>

--- a/src/shell/dotnet/Shell/WebContent.xaml.cs
+++ b/src/shell/dotnet/Shell/WebContent.xaml.cs
@@ -26,6 +26,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Web.WebView2.Core;
 using MorganStanley.ComposeUI.ModuleLoader;
 using MorganStanley.ComposeUI.Shell.ImageSource;
+using System.Windows;
 
 namespace MorganStanley.ComposeUI.Shell;
 
@@ -185,7 +186,13 @@ public partial class WebContent : ContentPresenter, IDisposable
                     {
                         var script = await scriptProvider(_moduleInstance!);
                         await coreWebView.AddScriptToExecuteOnDocumentCreatedAsync(script);
-                    }));
+                    })
+                );
+
+            if (webProperties.Fdc3ChannelSelectorControl is UIElement element)
+            {
+                LayoutRoot.Children.Add(element);
+            }
         }
 
         _scriptInjectionCompleted.SetResult();

--- a/src/shell/dotnet/test/Shell.Tests/Shell.Tests.csproj
+++ b/src/shell/dotnet/test/Shell.Tests/Shell.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFrameworkVersion)-windows</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
 	<RootNamespace>MorganStanley.ComposeUI.Shell</RootNamespace>


### PR DESCRIPTION
This PR introduces a new UI element that allows users to select the FDC3 Channel.
The ChannelSelector is leveraging WPF Material Design PopupBox, and rendered as an overlay thanks to the new [WebView2CompositionControl](https://learn.microsoft.com/en-us/microsoft-edge/webview2/release-notes/?tabs=dotnetcsharp#102957106) which solves the AirSpace Issue

Changes in this PR
* The Embedded WebBrowser is using **WebView2CompositionControl** as a drop-in replacement for the WebView2 Control. As this is using Direct3D under the hood the target framework had to be changed to **net8.0-windows10.0.17763.0**
* We register a communication channel for each instance dynamically so that each web module can be notified by it's channel selector control about the channel change and vice-versa.
* Fdc3ChannelSelectorStartupAction: the control is only added to the DOM if FDC3 is enabled.