### PR TITLE
chore(Shell): Fix path to ModuleCatalog in launchSettings.json

### DIFF
--- a/src/shell/dotnet/src/Shell/Properties/launchSettings.json
+++ b/src/shell/dotnet/src/Shell/Properties/launchSettings.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "profiles": {
     "Chart and grid": {
       "commandName": "Project",
-      "commandLineArgs": "--url http://localhost:4200\r\n --FDC3:AppDirectory:Source $(ComposeUIRepositoryRoot)/examples/fdc3-appdirectory/apps.json"
+      "commandLineArgs": "--url http://localhost:4200 --FDC3:EnableFdc3=false"
     },
     "Shell": {
       "commandName": "Project",
-      "commandLineArgs": "--ModuleCatalog:CatalogUrl \"file:///$(ProjectDir)..\\examples\\module-catalog.json\" --FDC3:AppDirectory:Source $(ComposeUIRepositoryRoot)/examples/fdc3-appdirectory/apps.json"
+      "commandLineArgs": "--ModuleCatalog:CatalogUrl \"file:///$(ProjectDir)..\\..\\examples\\module-catalog.json\" --FDC3:AppDirectory:Source $(ComposeUIRepositoryRoot)/examples/fdc3-appdirectory/apps.json"
     },
     "FINOS FDC3": {
       "commandName": "Project",
@@ -14,7 +14,7 @@
     },
     "PrivateChannels": {
       "commandName": "Project",
-      "commandLineArgs": "--ModuleCatalog:CatalogUrl \"file:///$(ProjectDir)..\\examples\\module-catalog.json\" --FDC3:AppDirectory:Source $(ComposeUIRepositoryRoot)/examples/fdc3-appdirectory/privatechannels.json"
+      "commandLineArgs": "--ModuleCatalog:CatalogUrl \"file:///$(ProjectDir)..\\..\\examples\\module-catalog.json\" --FDC3:AppDirectory:Source $(ComposeUIRepositoryRoot)/examples/fdc3-appdirectory/privatechannels.json"
     }
   }
 }


### PR DESCRIPTION
**Changes in this PR**

* Fixed the path to the example module catalog as the Shell solution's been moved
* Chart and Grid launch option is updated to not contain the FDC3 AppD anymore