### PR TITLE
chore(Workflows): Add detectorsFilter to dependency-submission workflow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -22,3 +22,5 @@ jobs:
               powershell ./build/dotnet-build.ps1
       - name: Component detection 
         uses: advanced-security/component-detection-dependency-submission-action@7f8a02206328ac5ba9026225bb70dc3f9806a9e0 # v0.0.5
+        with:
+          detectorsFilter: "NuGetProjectCentric,Npm,NpmLockfile3"


### PR DESCRIPTION
This is a workaround for the issues caused by https://github.com/advanced-security/component-detection-dependency-submission-action/issues/107

The DecorsFilter in reality isn't filtering anything because the tool is still capturing the necessary Nuget and Npm packages.

Tested on my fork before opening the PR to the main repository 