### PR TITLE
chore(workflows/dependency-submission): Create SBOM on .NET 8 and Node.js 22

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -12,6 +12,10 @@ jobs:
       id-token: write
       contents: write
     runs-on: windows-latest
+    strategy:
+      matrix:
+        dotnet-version: [ '8.0.x' ]
+        node-version: [ '22.x' ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build Components


### PR DESCRIPTION
**Changes in this PR**

* Specify versions for .NET (v8) and Node.js (v22), so SBOMs are created on the intended build tooling