### PR TITLE
Add MorganStanley.ComposeUI.Utilities to 0.1.0-alpha.6 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           COMPOSEUI_SKIP_DOWNLOAD: 'true'
 
   deploy-nuget:
-    name: Publish messaging packages to nuget.org
+    name: Publish Nuget packages to nuget.org
     runs-on: windows-latest
     needs: build
     env:
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: 8.0.x
-      - name: Publish Messaging packages
+      - name: Publish Nuget packages
         working-directory: ./packages
         run: |
              dotnet nuget push MorganStanley.ComposeUI.Messaging.Core.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source ${{ env.nuget_source }} --skip-duplicate
@@ -93,3 +93,4 @@ jobs:
              dotnet nuget push MorganStanley.ComposeUI.Fdc3.AppDirectory.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source ${{ env.nuget_source }} --skip-duplicate
              dotnet nuget push MorganStanley.ComposeUI.Fdc3.DesktopAgent.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source ${{ env.nuget_source }} --skip-duplicate
              dotnet nuget push MorganStanley.ComposeUI.ModuleLoader.Abstractions.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source ${{ env.nuget_source }} --skip-duplicate
+             dotnet nuget push MorganStanley.ComposeUI.Utilities.*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source ${{ env.nuget_source }} --skip-duplicate

--- a/package-lock.json
+++ b/package-lock.json
@@ -26301,7 +26301,7 @@
     },
     "src/fdc3/js/composeui-fdc3": {
       "name": "@morgan-stanley/composeui-fdc3",
-      "version": "0.1.0",
+      "version": "0.1.0-alpha.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@finos/fdc3": "~2.0.3",
@@ -26438,7 +26438,7 @@
     },
     "src/messaging/js/composeui-messaging-client": {
       "name": "@morgan-stanley/composeui-messaging-client",
-      "version": "0.1.0-alpha.4",
+      "version": "0.1.0-alpha.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^22.0.2",
@@ -26521,7 +26521,7 @@
     },
     "src/shell/js/composeui-node-launcher": {
       "name": "@morgan-stanley/composeui-node-launcher",
-      "version": "0.1.0-alpha.4",
+      "version": "0.1.0-alpha.6",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/shared/dotnet/src/MorganStanley.ComposeUI.Utilities/MorganStanley.ComposeUI.Utilities.csproj
+++ b/src/shared/dotnet/src/MorganStanley.ComposeUI.Utilities/MorganStanley.ComposeUI.Utilities.csproj
@@ -2,4 +2,15 @@
 	<ItemGroup>
 		<PackageReference Include="System.CommandLine" />
 	</ItemGroup>
+
+	<PropertyGroup>
+		<AssemblyName>MorganStanley.ComposeUI.Utilities</AssemblyName>
+		<RootNamespace>MorganStanley.ComposeUI.Utilities</RootNamespace>
+		<Description>Utilities for ComposeUI. More Details: https://morganstanley.github.io/ComposeUI/</Description>
+		<Tags>ComposeUI</Tags>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<IsPackable>true</IsPackable>
+	</PropertyGroup>
 </Project>


### PR DESCRIPTION
The MorganStanley.ComposeUI.Utilities package is a dependency of the DesktopAgent nuget package and missing from the latest release.

A manual run of the updated release workflow should release this missing package.