### PR TITLE
Revert "chore(deps): bump highcharts from 11.4.8 to 12.3.0"

### DIFF
--- a/examples/fdc3-chart-and-grid/js-chart/package.json
+++ b/examples/fdc3-chart-and-grid/js-chart/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@finos/fdc3": "^2.0.3",
     "bootstrap": "5.3.6",
-    "highcharts": "12.3.0",
+    "highcharts": "11.4.8",
     "jquery": "3.7.1",
     "tslib": "2.8.1"
   },

--- a/examples/js-chart-and-grid-messagerouter/js-chart/package.json
+++ b/examples/js-chart-and-grid-messagerouter/js-chart/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@morgan-stanley/composeui-messaging-client": "*",
     "bootstrap": "5.3.6",
-    "highcharts": "12.3.0",
+    "highcharts": "11.4.8",
     "jquery": "3.7.1",
     "tslib": "2.8.1"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 			"dependencies": {
 				"@finos/fdc3": "^2.0.3",
 				"bootstrap": "5.3.6",
-				"highcharts": "12.3.0",
+				"highcharts": "11.4.8",
 				"jquery": "3.7.1",
 				"tslib": "2.8.1"
 			},
@@ -380,7 +380,7 @@
 			"dependencies": {
 				"@morgan-stanley/composeui-messaging-client": "*",
 				"bootstrap": "5.3.6",
-				"highcharts": "12.3.0",
+				"highcharts": "11.4.8",
 				"jquery": "3.7.1",
 				"tslib": "2.8.1"
 			},
@@ -13234,9 +13234,10 @@
 			}
 		},
 		"node_modules/highcharts": {
-			"version": "12.3.0",
-			"resolved": "https://registry.npmjs.org/highcharts/-/highcharts-12.3.0.tgz",
-			"integrity": "sha512-QIKmaemgheRa1K2Ia9MLj1KLtBU1Tu/VQ6KAMqtMBMsAC4NzcFq6g96LF03ZO3IFFiSifmZx8ItEyRcz4w75cg=="
+			"version": "11.4.8",
+			"resolved": "https://registry.npmjs.org/highcharts/-/highcharts-11.4.8.tgz",
+			"integrity": "sha512-5Tke9LuzZszC4osaFisxLIcw7xgNGz4Sy3Jc9pRMV+ydm6sYqsPYdU8ELOgpzGNrbrRNDRBtveoR5xS3SzneEA==",
+			"license": "https://www.highcharts.com/license"
 		},
 		"node_modules/hosted-git-info": {
 			"version": "7.0.2",


### PR DESCRIPTION
This reverts commit 9b817ff03c36900177798176e1aacd398c317ce3.