### PR TITLE
Fix build warnings and enable warnings as errors

### DIFF
--- a/src/fdc3/js/composeui-fdc3/tsconfig.json
+++ b/src/fdc3/js/composeui-fdc3/tsconfig.json
@@ -9,7 +9,9 @@
       "declaration": true,
       "outDir": "output",
       "lib": [ "es2022", "DOM" ],
-      "strict": true
+      "strict": true,
+      "noImplicitReturns": true,
+      "noFallthroughCasesInSwitch": true
     },
     "files": [ "src/index.ts" ]
 }

--- a/src/messaging/js/composeui-messaging-abstractions/tsconfig.base.json
+++ b/src/messaging/js/composeui-messaging-abstractions/tsconfig.base.json
@@ -10,6 +10,10 @@
         "strict": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true,
+        "noUncheckedIndexedAccess": true,
+        "noPropertyAccessFromIndexSignature": true,
         "outDir": "dist",
         "lib": [
             "es2022",

--- a/src/messaging/js/composeui-messaging-client/src/client/MessageRouterClient.ts
+++ b/src/messaging/js/composeui-messaging-client/src/client/MessageRouterClient.ts
@@ -266,8 +266,12 @@ export class MessageRouterClient implements MessageRouter {
     }
 
     private failPendingRequests(error: any) {
-        for (let requestId in this.pendingRequests) {
-            this.pendingRequests[requestId].reject(error);
+        const requestIds = Object.keys(this.pendingRequests);
+        for (let requestId of requestIds) {
+            const deferred = this.pendingRequests[requestId];
+            if (deferred) {
+                deferred.reject(error);
+            }
             delete this.pendingRequests[requestId];
         }
     }
@@ -275,7 +279,9 @@ export class MessageRouterClient implements MessageRouter {
     private async failSubscribers(error: any) {
         for (let topicName in this.topics) {
             const topic = this.topics[topicName];
-            topic.error(error);
+            if (topic) {
+                topic.error(error);
+            }
         }
     }
 

--- a/src/messaging/js/composeui-messaging-client/tsconfig.base.json
+++ b/src/messaging/js/composeui-messaging-client/tsconfig.base.json
@@ -10,6 +10,10 @@
         "strict": true,
         "noImplicitAny": true,
         "noImplicitThis": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true,
+        "noUncheckedIndexedAccess": true,
+        "noPropertyAccessFromIndexSignature": true,
         "outDir": "dist",
         "lib": [
             "es2022",

--- a/src/messaging/js/composeui-messaging-message-router/tsconfig.json
+++ b/src/messaging/js/composeui-messaging-message-router/tsconfig.json
@@ -7,7 +7,9 @@
     "outDir": "output",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.test.ts"]

--- a/src/shell/js/composeui-node-launcher/tsconfig.json
+++ b/src/shell/js/composeui-node-launcher/tsconfig.json
@@ -9,7 +9,9 @@
     "declaration": true,
     "outDir": "output",
     "lib": [ "es2022", "DOM" ],
-    "strict": true
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
   },
   "files": [ "src/index.ts" ]
 }


### PR DESCRIPTION
Address build warnings by adding strict TypeScript compiler options and ensuring proper error handling in the code. This change improves code quality and reliability.